### PR TITLE
Better errors

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -69,7 +69,7 @@ pub async fn target_message_handler<T: HttpClient>(
             // Body is as per OpenAI's response
             body: Some(ErrorResponseBody {
                 message: format!("The model `{}` does not exist or you do not have access to it.", model.model),
-                type_: "invalid_request_error".to_string(),
+                r#type: "invalid_request_error".to_string(),
                 param: None,
                 code: "model_not_found".to_string(),
             }),

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,6 +1,7 @@
 /// Axum handlers for the proxy server
 use crate::client::HttpClient;
-use crate::models::ListModelResponse;
+use crate::models::{ErrorResponseBody, ListModelResponse};
+use crate::models::OnwardsErrorResponse;
 use crate::{AppState, models::ExtractedModel};
 use axum::{
     Json,
@@ -21,13 +22,16 @@ const MODEL_OVERRIDE_HEADER: &str = "model-override";
 pub async fn target_message_handler<T: HttpClient>(
     State(state): State<AppState<T>>,
     mut req: axum::extract::Request,
-) -> Result<Response, StatusCode> {
+) -> Result<Response, OnwardsErrorResponse> {
     // Extract the request body. TODO(fergus): make this step conditional: its not necessary if we
     // extract the model from the header.
     let mut body_bytes =
         match axum::body::to_bytes(std::mem::take(req.body_mut()), usize::MAX).await {
             Ok(bytes) => bytes,
-            Err(_) => return Err(StatusCode::BAD_REQUEST),
+            Err(_) => return Err(OnwardsErrorResponse {
+                body: None,
+                status: StatusCode::BAD_REQUEST,
+            }),
         };
 
     // Order of precedence for the target to use:
@@ -38,7 +42,10 @@ pub async fn target_message_handler<T: HttpClient>(
         Some(header_value) => {
             let model_str = match header_value.to_str() {
                 Ok(value) => value,
-                Err(_) => return Err(StatusCode::BAD_REQUEST),
+                Err(_) => return Err(OnwardsErrorResponse {
+                    body: None,
+                    status: StatusCode::BAD_REQUEST,
+                }),
             };
             debug!("Using model override from header: {}", model_str);
             ExtractedModel { model: model_str }
@@ -47,7 +54,10 @@ pub async fn target_message_handler<T: HttpClient>(
             debug!("Received request body of size: {}", body_bytes.len());
             match serde_json::from_slice(&body_bytes) {
                 Ok(model) => model,
-                Err(_) => return Err(StatusCode::BAD_REQUEST),
+                Err(_) => return Err(OnwardsErrorResponse {
+                    body: None,
+                    status: StatusCode::BAD_REQUEST,
+                }),
             }
         }
     };
@@ -81,11 +91,17 @@ pub async fn target_message_handler<T: HttpClient>(
         debug!("Rewriting model key to: {}", rewrite);
         let mut body_serialized: serde_json::Value = match serde_json::from_slice(&body_bytes) {
             Ok(value) => value,
-            Err(_) => return Err(StatusCode::BAD_REQUEST),
+            Err(_) => return Err(OnwardsErrorResponse {
+                body: None,
+                status: StatusCode::BAD_REQUEST,
+            }),
         };
         let entry = body_serialized
             .as_object_mut()
-            .ok_or(StatusCode::BAD_REQUEST)? // if the body is not an object (we know its not empty), return 400
+            .ok_or(OnwardsErrorResponse {
+                body: None,
+                status: StatusCode::BAD_REQUEST,
+            })? // if the body is not an object (we know its not empty), return 400
             .entry("model");
         match entry {
             Entry::Occupied(mut entry) => {
@@ -95,12 +111,18 @@ pub async fn target_message_handler<T: HttpClient>(
             Entry::Vacant(_entry) => {
                 // If the body didn't have a model key, then 400 (header shouldn't have been
                 // provided)
-                return Err(StatusCode::BAD_REQUEST);
+                return Err(OnwardsErrorResponse {
+                    body: None,
+                    status: StatusCode::BAD_REQUEST,
+                });
             }
         }
         body_bytes = match serde_json::to_vec(&body_serialized) {
             Ok(bytes) => axum::body::Bytes::from(bytes),
-            Err(_) => return Err(StatusCode::BAD_REQUEST),
+            Err(_) => return Err(OnwardsErrorResponse {
+                body: None,
+                status: StatusCode::BAD_REQUEST,
+            }),
         };
 
         // Update Content-Length header to match the new body size
@@ -125,13 +147,19 @@ pub async fn target_message_handler<T: HttpClient>(
     let upstream_uri = target
         .url
         .join(path_and_query.strip_prefix('/').unwrap_or(path_and_query))
-        .map_err(|_| StatusCode::BAD_REQUEST)?
+        .map_err(|_| OnwardsErrorResponse {
+            body: None,
+            status: StatusCode::BAD_REQUEST,
+        })?
         .to_string();
     let upstream_uri_parsed = match Uri::try_from(&upstream_uri) {
         Ok(uri) => uri,
         Err(_) => {
             error!("Invalid URI: {}", upstream_uri);
-            return Err(StatusCode::BAD_REQUEST);
+            return Err(OnwardsErrorResponse {
+                body: None,
+                status: StatusCode::BAD_REQUEST,
+            });
         }
     };
 
@@ -164,7 +192,10 @@ pub async fn target_message_handler<T: HttpClient>(
                 "Error forwarding request to target url {}: {}",
                 upstream_uri, e
             );
-            Err(StatusCode::BAD_GATEWAY)
+            Err(OnwardsErrorResponse {
+                body: None,
+                status: StatusCode::BAD_GATEWAY,
+            })
         }
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -11,8 +11,7 @@ use crate::target::{Target, Targets};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct ErrorResponseBody {   
     pub(crate) message: String,
-    #[serde(rename = "type")]
-    pub(crate) type_: String,
+    pub(crate) r#type: String,
     pub(crate) param: Option<String>,
     pub(crate) code: String,
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -2,6 +2,11 @@
 /// This endpoint mimics the openai API's models endpoint. Each 'model' is actually a target to
 /// forward requests onto.
 use serde::{Deserialize, Serialize};
+use crate::target::{Target, Targets};
+use axum::Json;
+use axum::response::Response;
+use axum::response::IntoResponse;
+use hyper::StatusCode;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct ErrorResponseBody {   
@@ -9,6 +14,19 @@ pub(crate) struct ErrorResponseBody {
     pub(crate) r#type: String,
     pub(crate) param: Option<String>,
     pub(crate) code: String,
+}
+#[derive(Debug, Clone)]
+pub(crate) struct OnwardsErrorResponse {
+    pub(crate) body: Option<ErrorResponseBody>,
+    pub(crate) status: StatusCode,
+}
+impl IntoResponse for OnwardsErrorResponse {
+    fn into_response(self) -> Response {
+        match self.body {
+            Some(body) => (self.status, Json(body)).into_response(),
+            None => self.status.into_response(), // No body, just status
+        }
+    }
 }
 
 /// Requests to the /v1/{*} endpoints get forwarded onto OpenAI compatible targets.


### PR DESCRIPTION

as per the todo: in models, we're responding to failing http requests with just a status code.  

for example, when requesting a non-existent model, onwards will return '404', no body

openai will return '404', with a body:
```
{
  "error": {
    "message": "The model `melons` does not exist or you do not have access to it.",
    "type": "invalid_request_error",
    "param": null,
    "code": "model_not_found"
  }
} 
```