### PR TITLE
fix: make created field required in Model struct per OpenAI spec

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -19,7 +19,7 @@ pub(crate) struct Model {
     /// The model identifier, which can be referenced in the API endpoints.
     pub(crate) id: String,
     /// The Unix timestamp (in seconds) when the model was created.
-    pub(crate) created: Option<u32>,
+    pub(crate) created: u32,
     /// The object type, which is always "model".
     pub(crate) object: String,
     /// The organization that owns the model.
@@ -31,7 +31,10 @@ impl Model {
     pub(crate) fn from_target(id: &str, _target: &Target) -> Self {
         Model {
             id: id.to_owned(),
-            created: None,
+            created: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs() as u32,
             object: "model".into(),
             owned_by: "None".into(),
         }


### PR DESCRIPTION
## Summary
- Changes `created` field from `Option<u32>` to `u32` in the Model struct to match OpenAI API specification
- Updates `from_target` method to generate actual Unix timestamp instead of returning None

## Test plan
- [ ] Verify /v1/models endpoint returns proper created timestamps
- [ ] Ensure existing functionality remains intact