### PR TITLE
Fix /v1/models endpoint bearer token filtering

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -3,7 +3,8 @@
 /// forward requests onto.
 use serde::{Deserialize, Serialize};
 
-use crate::target::{Target, Targets};
+use crate::target::Target;
+use std::collections::HashMap;
 
 /// Requests to the /v1/{*} endpoints get forwarded onto OpenAI compatible targets.
 /// The target is chosen based on the model specified in the request body.
@@ -51,12 +52,11 @@ pub(crate) struct ListModelResponse {
 }
 
 impl ListModelResponse {
-    /// Creates a new ListModelResponse from the given Targets.
-    pub(crate) fn from_targets(targets: &Targets) -> Self {
+    /// Creates a new ListModelResponse from a filtered HashMap of targets.
+    pub(crate) fn from_filtered_targets(targets: &HashMap<String, Target>) -> Self {
         let data = targets
-            .targets
             .iter()
-            .map(|item| Model::from_target(item.key(), item.value()))
+            .map(|(key, target)| Model::from_target(key, target))
             .collect::<Vec<_>>();
         ListModelResponse {
             object: "list".into(),


### PR DESCRIPTION
## Summary
- Fixes security issue where `/v1/models` endpoint showed all models regardless of bearer token permissions
- Models are now properly filtered based on the provided bearer token
- Public models (no keys configured) remain accessible to all users

## Changes
- Modified `/v1/models` endpoint to extract and validate bearer tokens from Authorization header
- Added filtering logic that only shows models the token has access to plus public models  
- Updated `ListModelResponse` to work with filtered HashMap instead of all targets
- Added comprehensive test coverage for all authentication scenarios

## Test plan
- [x] No bearer token: only shows public models
- [x] Valid bearer token: shows permitted models + public models
- [x] Invalid bearer token: only shows public models
- [x] All existing tests still pass
- [x] New test `test_models_endpoint_filters_by_bearer_token` validates the fix

Closes #14