### PR TITLE
feat: rate limits + structured errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -613,6 +619,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
@@ -627,9 +634,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -645,6 +654,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
+name = "governor"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "444405bbb1a762387aa22dd569429533b54a1d8759d35d3b64cb39b0293eaa19"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "getrandom",
+ "hashbrown 0.15.4",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rand",
+ "smallvec",
+ "spinning_top",
+ "web-time",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,6 +688,8 @@ version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -1110,6 +1144,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
+
+[[package]]
 name = "notify"
 version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1183,6 +1223,7 @@ dependencies = [
  "clap",
  "dashmap",
  "futures-util",
+ "governor",
  "hyper",
  "hyper-tls",
  "hyper-util",
@@ -1247,6 +1288,16 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
 
 [[package]]
 name = "parking_lot_core"
@@ -1753,6 +1804,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2235,6 +2295,16 @@ name = "web-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ url = { version = "2.5", features = ["serde"] }
 bon = "3.6.5"
 subtle = "2.6.1"
 axum-prometheus = "0.8.0"
+governor = "0.10.1"
 
 [dev-dependencies]
 axum-test = "17.3.0"

--- a/README.md
+++ b/README.md
@@ -98,21 +98,6 @@ curl -X GET http://localhost:3000/v1/organization/usage/embeddings \
   -H "model-override: claude-3"
 ```
 
-### Onwards Model Header
-
-Rewrite the model name in the request body using the `onwards-model` header
-(necessary for forwarding to openAI, for example):
-
-```bash
-curl -X POST http://localhost:3000/v1/chat/completions \
-  -H "onwards-model: gpt-4-turbo" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "gpt-4",
-    "messages": [{"role": "user", "content": "Hello!"}]
-  }'
-```
-
 ### Metrics
 
 To enable Prometheus metrics, start the gateway with the `--metrics` flag, then access the metrics endpoint by:

--- a/README.md
+++ b/README.md
@@ -223,6 +223,57 @@ curl -X POST http://localhost:3000/v1/chat/completions \
 # Success - no authentication required for this target
 ```
 
+## Rate Limiting
+
+Onwards supports per-target rate limiting using a token bucket algorithm. This
+allows you to control the request rate to each AI provider independently.
+
+### Configuration
+
+Add rate limiting to any target in your `config.json`:
+
+```json
+{
+  "targets": {
+    "rate-limited-model": {
+      "url": "https://api.provider.com",
+      "key": "your-api-key",
+      "rate_limit": {
+        "requests_per_second": 5.0,
+        "burst_size": 10
+      }
+    }
+  }
+}
+```
+
+### How It Works
+
+We use a "Token Bucket Algorithm": Each target gets its own token bucket.Tokens
+are refilled at a rate determined by the "requests_per_second" parameter. The
+maximum number of tokens in the bucket is determined by the "burst_size"
+parameter. When the bucket is empty, requests to that target will be rejected
+with a `429 Too Many Requests` response.
+
+### Examples
+
+```json
+// Allow 1 request per second with burst of 5
+"rate_limit": {
+  "requests_per_second": 1.0,
+  "burst_size": 5
+}
+
+// Allow 100 requests per second with burst of 200  
+"rate_limit": {
+  "requests_per_second": 100.0,
+  "burst_size": 200
+}
+```
+
+Rate limiting is optional - targets without `rate_limit` configuration have no
+rate limiting applied.
+
 ## Testing
 
 Run the test suite:

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,131 @@
+use axum::{
+    Json,
+    response::{IntoResponse, Response},
+};
+use bon::Builder;
+use hyper::StatusCode;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ErrorResponseBody {
+    pub message: String,
+    pub r#type: String,
+    pub param: Option<String>,
+    pub code: String,
+}
+
+#[derive(Debug, Clone, Builder)]
+pub struct OnwardsErrorResponse {
+    pub body: Option<ErrorResponseBody>,
+    pub status: StatusCode,
+}
+
+impl OnwardsErrorResponse {
+    pub fn model_not_found(model: &str) -> Self {
+        OnwardsErrorResponse {
+            body: Some(ErrorResponseBody {
+                message: format!(
+                    "The model `{model}` does not exist or you do not have access to it."
+                ),
+                r#type: "invalid_request_error".to_string(),
+                param: None,
+                code: "model_not_found".to_string(),
+            }),
+            status: StatusCode::NOT_FOUND,
+        }
+    }
+
+    pub fn rate_limited() -> Self {
+        OnwardsErrorResponse {
+            body: Some(ErrorResponseBody {
+                message: "You are sending requests too quickly. Please slow down.".to_string(),
+                r#type: "rate_limit_error".to_string(),
+                param: None,
+                code: "rate_limit".to_string(),
+            }),
+            status: StatusCode::TOO_MANY_REQUESTS,
+        }
+    }
+
+    pub fn internal() -> Self {
+        OnwardsErrorResponse {
+            body: Some(ErrorResponseBody {
+                message: "An internal error occurred. Please try again later.".to_string(),
+                r#type: "internal_error".to_string(),
+                param: None,
+                code: "internal_error".to_string(),
+            }),
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+
+    pub fn bad_gateway() -> Self {
+        OnwardsErrorResponse {
+            body: Some(ErrorResponseBody {
+                message: "An internal error occurred. Please try again later.".to_string(),
+                r#type: "internal_error".to_string(),
+                param: None,
+                code: "internal_error".to_string(),
+            }),
+            status: StatusCode::BAD_GATEWAY,
+        }
+    }
+
+    pub fn unprocessable_request(message: &str, param: Option<&str>) -> Self {
+        OnwardsErrorResponse {
+            body: Some(ErrorResponseBody {
+                message: message.to_owned(),
+                r#type: "invalid_request_error".to_string(),
+                param: param.map(|s| s.to_string()),
+                code: "unprocessable_request".to_string(),
+            }),
+            status: StatusCode::UNPROCESSABLE_ENTITY,
+        }
+    }
+
+    pub fn bad_request(message: &str, param: Option<&str>) -> Self {
+        OnwardsErrorResponse {
+            body: Some(ErrorResponseBody {
+                message: message.to_owned(),
+                r#type: "invalid_request_error".to_string(),
+                param: param.map(|s| s.to_string()),
+                code: "bad_request".to_string(),
+            }),
+            status: StatusCode::BAD_REQUEST,
+        }
+    }
+
+    pub fn forbidden() -> Self {
+        OnwardsErrorResponse {
+            body: Some(ErrorResponseBody {
+                message: "Unauthorized".to_string(),
+                r#type: "invalid_request_error".to_string(),
+                param: None,
+                code: "unauthorized".to_string(),
+            }),
+            status: StatusCode::FORBIDDEN,
+        }
+    }
+
+    pub fn unauthorized() -> Self {
+        OnwardsErrorResponse {
+            body: Some(ErrorResponseBody {
+                message: "Please supply an authentication token to access this resource"
+                    .to_string(),
+                r#type: "invalid_request_error".to_string(),
+                param: None,
+                code: "unauthenticated".to_string(),
+            }),
+            status: StatusCode::UNAUTHORIZED,
+        }
+    }
+}
+
+impl IntoResponse for OnwardsErrorResponse {
+    fn into_response(self) -> Response {
+        match self.body {
+            Some(body) => (self.status, Json(body)).into_response(),
+            None => self.status.into_response(), // No body, just status
+        }
+    }
+}

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -2,13 +2,14 @@ use crate::AppState;
 /// Axum handlers for the proxy server
 use crate::auth;
 use crate::client::HttpClient;
+use crate::errors::OnwardsErrorResponse;
 use crate::models::ListModelResponse;
 use axum::{
     Json,
     extract::Request,
     extract::State,
     http::{
-        StatusCode, Uri,
+        Uri,
         header::{CONTENT_LENGTH, TRANSFER_ENCODING},
     },
     response::{IntoResponse, Response},
@@ -23,13 +24,14 @@ use tracing::{debug, error, instrument, trace};
 pub async fn target_message_handler<T: HttpClient>(
     State(state): State<AppState<T>>,
     mut req: axum::extract::Request,
-) -> Result<Response, StatusCode> {
+) -> Result<Response, OnwardsErrorResponse> {
     // Extract the request body. TODO(fergus): make this step conditional: its not necessary if we
     // extract the model from the header.
     let mut body_bytes =
         match axum::body::to_bytes(std::mem::take(req.body_mut()), usize::MAX).await {
             Ok(bytes) => bytes,
-            Err(_) => return Err(StatusCode::BAD_REQUEST),
+            Err(_) => return Err(OnwardsErrorResponse::internal()), // since there's no body limit,
+                                                                    // this should never fail.
         };
 
     // Log full incoming request details for debugging
@@ -44,7 +46,12 @@ pub async fn target_message_handler<T: HttpClient>(
     // Extract the model using the shared function
     let model_name = match crate::extract_model_from_request(req.headers(), &body_bytes) {
         Ok(model) => model,
-        Err(_) => return Err(StatusCode::BAD_REQUEST),
+        Err(_) => {
+            return Err(OnwardsErrorResponse::bad_request(
+                "Could not parse onwards model from request. 'model' parameter must be supplied in either the body or in the Model-Override header.",
+                Some("model"),
+            ));
+        }
     };
 
     trace!("Received request for model: {}", model_name);
@@ -65,7 +72,7 @@ pub async fn target_message_handler<T: HttpClient>(
         }
         None => {
             debug!("No target found for model: {}", model_name);
-            return Err(StatusCode::NOT_FOUND);
+            return Err(OnwardsErrorResponse::model_not_found(model_name.as_str()));
         }
     };
 
@@ -84,12 +91,12 @@ pub async fn target_message_handler<T: HttpClient>(
                     debug!("Bearer token validation successful");
                 } else {
                     debug!("Bearer token validation failed - token not in key set");
-                    return Err(StatusCode::UNAUTHORIZED);
+                    return Err(OnwardsErrorResponse::forbidden());
                 }
             }
             None => {
                 debug!("No bearer token found in authorization header");
-                return Err(StatusCode::UNAUTHORIZED);
+                return Err(OnwardsErrorResponse::unauthorized());
             }
         }
     } else {
@@ -105,13 +112,17 @@ pub async fn target_message_handler<T: HttpClient>(
         && !body_bytes.is_empty()
     {
         debug!("Rewriting model key to: {}", rewrite);
+        let error = OnwardsErrorResponse::bad_request(
+            "Could not parse onwards model from request. 'model' parameter must be supplied in either the body or in the Model-Override header.",
+            Some("model"),
+        );
         let mut body_serialized: serde_json::Value = match serde_json::from_slice(&body_bytes) {
             Ok(value) => value,
-            Err(_) => return Err(StatusCode::BAD_REQUEST),
+            Err(_) => return Err(error.clone()),
         };
         let entry = body_serialized
             .as_object_mut()
-            .ok_or(StatusCode::BAD_REQUEST)? // if the body is not an object (we know its not empty), return 400
+            .ok_or(error.clone())? // if the body is not an object (we know its not empty), return 400
             .entry("model");
         match entry {
             Entry::Occupied(mut entry) => {
@@ -121,12 +132,12 @@ pub async fn target_message_handler<T: HttpClient>(
             Entry::Vacant(_entry) => {
                 // If the body didn't have a model key, then 400 (header shouldn't have been
                 // provided)
-                return Err(StatusCode::BAD_REQUEST);
+                return Err(error.clone());
             }
         }
         body_bytes = match serde_json::to_vec(&body_serialized) {
             Ok(bytes) => axum::body::Bytes::from(bytes),
-            Err(_) => return Err(StatusCode::BAD_REQUEST),
+            Err(_) => return Err(OnwardsErrorResponse::internal()),
         };
     }
 
@@ -139,13 +150,13 @@ pub async fn target_message_handler<T: HttpClient>(
     let upstream_uri = target
         .url
         .join(path_and_query.strip_prefix('/').unwrap_or(path_and_query))
-        .map_err(|_| StatusCode::BAD_REQUEST)?
+        .map_err(|_| OnwardsErrorResponse::internal())?
         .to_string();
     let upstream_uri_parsed = match Uri::try_from(&upstream_uri) {
         Ok(uri) => uri,
         Err(_) => {
             error!("Invalid URI: {}", upstream_uri);
-            return Err(StatusCode::BAD_REQUEST);
+            return Err(OnwardsErrorResponse::internal());
         }
     };
 
@@ -200,7 +211,7 @@ pub async fn target_message_handler<T: HttpClient>(
                 "Error forwarding request to target url {}: {}",
                 upstream_uri, e
             );
-            Err(StatusCode::BAD_GATEWAY)
+            Err(OnwardsErrorResponse::bad_gateway())
         }
     }
 }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -76,6 +76,12 @@ pub async fn target_message_handler<T: HttpClient>(
         }
     };
 
+    if let Some(ref limiter) = target.limiter {
+        if limiter.check().is_err() {
+            return Err(OnwardsErrorResponse::rate_limited());
+        }
+    }
+
     // Validate API key if target has keys configured
     if let Some(ref keys) = target.keys {
         let bearer_token = req

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -16,7 +16,6 @@ use axum::{
 use serde_json::map::Entry;
 use tracing::{debug, error, instrument, trace};
 
-const ONWARD_MODEL_HEADER: &str = "onwards-model";
 
 /// The main handler responsible for forwarding requests to targets
 /// TODO(fergus): Better error messages beyond raw status codes.
@@ -100,14 +99,9 @@ pub async fn target_message_handler<T: HttpClient>(
         );
     }
 
-    // Users can specify the onwards value of the model field via a header, or it can be specified in the target
-    // config. If neither is supplied, its left as is.
-    if let Some(rewrite) = req
-        .headers()
-        .get(ONWARD_MODEL_HEADER)
-        .and_then(|x| x.to_str().ok())
-        .map(|x| x.to_owned())
-        .or(target.onwards_model.clone())
+    // Users can specify the onwards value of the model field in the target
+    // config. If not supplied, its left as is.
+    if let Some(rewrite) = target.onwards_model.clone()
         && !body_bytes.is_empty()
     {
         debug!("Rewriting model key to: {}", rewrite);

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -17,7 +17,6 @@ use axum::{
 use serde_json::map::Entry;
 use tracing::{debug, error, instrument, trace};
 
-
 /// The main handler responsible for forwarding requests to targets
 /// TODO(fergus): Better error messages beyond raw status codes.
 #[instrument(skip(state, req))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -574,13 +574,13 @@ mod tests {
         // Create keys for different models
         let mut gpt4_keys = HashSet::new();
         gpt4_keys.insert(ConstantTimeString::from("gpt4-token".to_string()));
-        
+
         let mut claude_keys = HashSet::new();
         claude_keys.insert(ConstantTimeString::from("claude-token".to_string()));
 
         // Create targets with different access keys
         let targets_map = Arc::new(DashMap::new());
-        
+
         // gpt-4: requires gpt4-token
         targets_map.insert(
             "gpt-4".to_string(),
@@ -589,7 +589,7 @@ mod tests {
                 .keys(gpt4_keys)
                 .build(),
         );
-        
+
         // claude-3: requires claude-token
         targets_map.insert(
             "claude-3".to_string(),
@@ -598,7 +598,7 @@ mod tests {
                 .keys(claude_keys)
                 .build(),
         );
-        
+
         // gemini-pro: no keys required (public)
         targets_map.insert(
             "gemini-pro".to_string(),
@@ -619,11 +619,11 @@ mod tests {
         // Test 1: No bearer token - should only see public models
         let response = server.get("/v1/models").await;
         assert_eq!(response.status_code(), 200);
-        
+
         let response_body: serde_json::Value = response.json();
         let models = response_body["data"].as_array().unwrap();
         assert_eq!(models.len(), 1); // Only gemini-pro
-        
+
         let model_ids: Vec<&str> = models
             .iter()
             .map(|model| model["id"].as_str().unwrap())
@@ -636,11 +636,11 @@ mod tests {
             .add_header("authorization", "Bearer gpt4-token")
             .await;
         assert_eq!(response.status_code(), 200);
-        
+
         let response_body: serde_json::Value = response.json();
         let models = response_body["data"].as_array().unwrap();
         assert_eq!(models.len(), 2); // gpt-4 + gemini-pro
-        
+
         let model_ids: Vec<&str> = models
             .iter()
             .map(|model| model["id"].as_str().unwrap())
@@ -654,11 +654,11 @@ mod tests {
             .add_header("authorization", "Bearer claude-token")
             .await;
         assert_eq!(response.status_code(), 200);
-        
+
         let response_body: serde_json::Value = response.json();
         let models = response_body["data"].as_array().unwrap();
         assert_eq!(models.len(), 2); // claude-3 + gemini-pro
-        
+
         let model_ids: Vec<&str> = models
             .iter()
             .map(|model| model["id"].as_str().unwrap())
@@ -672,11 +672,11 @@ mod tests {
             .add_header("authorization", "Bearer invalid-token")
             .await;
         assert_eq!(response.status_code(), 200);
-        
+
         let response_body: serde_json::Value = response.json();
         let models = response_body["data"].as_array().unwrap();
         assert_eq!(models.len(), 1); // Only gemini-pro
-        
+
         let model_ids: Vec<&str> = models
             .iter()
             .map(|model| model["id"].as_str().unwrap())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ use tracing::{info, instrument};
 
 pub mod auth;
 pub mod client;
+pub mod errors;
 pub mod handlers;
 pub mod models;
 pub mod target;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -685,6 +685,208 @@ mod tests {
         assert!(model_ids.contains(&"gemini-pro"));
     }
 
+    #[tokio::test]
+    async fn test_rate_limiting_blocks_requests() {
+        use crate::target::{RateLimiter, Target, Targets};
+        use std::sync::Arc;
+
+        // Create a mock rate limiter that blocks requests
+        #[derive(Debug)]
+        struct BlockingRateLimiter;
+
+        impl RateLimiter for BlockingRateLimiter {
+            fn check(&self) -> Result<(), ()> {
+                Err(()) // Always block
+            }
+        }
+
+        // Create a target with a blocking rate limiter
+        let targets_map = Arc::new(DashMap::new());
+        targets_map.insert(
+            "rate-limited-model".to_string(),
+            Target::builder()
+                .url("https://api.example.com".parse().unwrap())
+                .limiter(Arc::new(BlockingRateLimiter) as Arc<dyn RateLimiter>)
+                .build(),
+        );
+
+        let targets = Targets {
+            targets: targets_map,
+        };
+
+        let mock_client = MockHttpClient::new(StatusCode::OK, r#"{"success": true}"#);
+        let app_state = AppState::with_client(targets, mock_client.clone());
+        let router = build_router(app_state);
+        let server = TestServer::new(router).unwrap();
+
+        // Make a request to the rate-limited model
+        let response = server
+            .post("/v1/chat/completions")
+            .json(&json!({
+                "model": "rate-limited-model",
+                "messages": [{"role": "user", "content": "Hello"}]
+            }))
+            .await;
+
+        // Should get 429 Too Many Requests
+        assert_eq!(response.status_code(), 429);
+
+        // Should return proper error structure
+        let response_body: serde_json::Value = response.json();
+        assert_eq!(response_body["type"], "rate_limit_error");
+        assert_eq!(response_body["code"], "rate_limit");
+
+        // Verify no request was made to the upstream (since it was rate limited)
+        let requests = mock_client.get_requests();
+        assert_eq!(requests.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_rate_limiting_allows_requests() {
+        use crate::target::{RateLimiter, Target, Targets};
+        use std::sync::Arc;
+
+        // Create a mock rate limiter that allows requests
+        #[derive(Debug)]
+        struct AllowingRateLimiter;
+
+        impl RateLimiter for AllowingRateLimiter {
+            fn check(&self) -> Result<(), ()> {
+                Ok(()) // Always allow
+            }
+        }
+
+        // Create a target with an allowing rate limiter
+        let targets_map = Arc::new(DashMap::new());
+        targets_map.insert(
+            "rate-limited-model".to_string(),
+            Target::builder()
+                .url("https://api.example.com".parse().unwrap())
+                .limiter(Arc::new(AllowingRateLimiter) as Arc<dyn RateLimiter>)
+                .build(),
+        );
+
+        let targets = Targets {
+            targets: targets_map,
+        };
+
+        let mock_client = MockHttpClient::new(StatusCode::OK, r#"{"success": true}"#);
+        let app_state = AppState::with_client(targets, mock_client.clone());
+        let router = build_router(app_state);
+        let server = TestServer::new(router).unwrap();
+
+        // Make a request to the rate-limited model
+        let response = server
+            .post("/v1/chat/completions")
+            .json(&json!({
+                "model": "rate-limited-model",
+                "messages": [{"role": "user", "content": "Hello"}]
+            }))
+            .await;
+
+        // Should get 200 OK since rate limiter allows it
+        assert_eq!(response.status_code(), 200);
+
+        // Verify request was made to the upstream
+        let requests = mock_client.get_requests();
+        assert_eq!(requests.len(), 1);
+        assert!(requests[0].uri.contains("api.example.com"));
+    }
+
+    #[tokio::test]
+    async fn test_rate_limiting_with_mixed_targets() {
+        use crate::target::{RateLimiter, Target, Targets};
+        use std::sync::Arc;
+
+        // Create different rate limiters
+        #[derive(Debug)]
+        struct BlockingRateLimiter;
+        impl RateLimiter for BlockingRateLimiter {
+            fn check(&self) -> Result<(), ()> {
+                Err(())
+            }
+        }
+
+        #[derive(Debug)]
+        struct AllowingRateLimiter;
+        impl RateLimiter for AllowingRateLimiter {
+            fn check(&self) -> Result<(), ()> {
+                Ok(())
+            }
+        }
+
+        // Create targets with different rate limiting behavior
+        let targets_map = Arc::new(DashMap::new());
+        targets_map.insert(
+            "blocked-model".to_string(),
+            Target::builder()
+                .url("https://blocked.example.com".parse().unwrap())
+                .limiter(Arc::new(BlockingRateLimiter) as Arc<dyn RateLimiter>)
+                .build(),
+        );
+        targets_map.insert(
+            "allowed-model".to_string(),
+            Target::builder()
+                .url("https://allowed.example.com".parse().unwrap())
+                .limiter(Arc::new(AllowingRateLimiter) as Arc<dyn RateLimiter>)
+                .build(),
+        );
+        targets_map.insert(
+            "unlimited-model".to_string(),
+            Target::builder()
+                .url("https://unlimited.example.com".parse().unwrap())
+                .build(), // No rate limiter
+        );
+
+        let targets = Targets {
+            targets: targets_map,
+        };
+
+        let mock_client = MockHttpClient::new(StatusCode::OK, r#"{"success": true}"#);
+        let app_state = AppState::with_client(targets, mock_client.clone());
+        let router = build_router(app_state);
+        let server = TestServer::new(router).unwrap();
+
+        // Test blocked model - should get 429
+        let response = server
+            .post("/v1/chat/completions")
+            .json(&json!({
+                "model": "blocked-model",
+                "messages": [{"role": "user", "content": "Hello"}]
+            }))
+            .await;
+        assert_eq!(response.status_code(), 429);
+
+        // Test allowed model - should get 200
+        let response = server
+            .post("/v1/chat/completions")
+            .json(&json!({
+                "model": "allowed-model",
+                "messages": [{"role": "user", "content": "Hello"}]
+            }))
+            .await;
+        assert_eq!(response.status_code(), 200);
+
+        // Test unlimited model - should get 200
+        let response = server
+            .post("/v1/chat/completions")
+            .json(&json!({
+                "model": "unlimited-model",
+                "messages": [{"role": "user", "content": "Hello"}]
+            }))
+            .await;
+        assert_eq!(response.status_code(), 200);
+
+        // Verify only allowed and unlimited models made upstream requests
+        let requests = mock_client.get_requests();
+        assert_eq!(requests.len(), 2);
+
+        let urls: Vec<&str> = requests.iter().map(|r| r.uri.as_str()).collect();
+        assert!(urls.contains(&"https://allowed.example.com/v1/chat/completions"));
+        assert!(urls.contains(&"https://unlimited.example.com/v1/chat/completions"));
+        assert!(!urls.iter().any(|&url| url.contains("blocked.example.com")));
+    }
+
     mod metrics {
         use super::*;
         use axum_test::TestServer;

--- a/src/target.rs
+++ b/src/target.rs
@@ -621,7 +621,7 @@ mod tests {
                 .url("https://api.example.com".parse().unwrap())
                 .rate_limit(RateLimitParameters {
                     requests_per_second: NonZeroU32::new(10).unwrap(),
-                    burst_size: NonZeroU32::new(20).unwrap(),
+                    burst_size: Some(NonZeroU32::new(20).unwrap()),
                 })
                 .build(),
         );

--- a/src/target.rs
+++ b/src/target.rs
@@ -22,7 +22,7 @@ use url::Url;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RateLimitParameters {
     pub requests_per_second: NonZeroU32,
-    pub burst_size: NonZeroU32,
+    pub burst_size: Option<NonZeroU32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Builder)]
@@ -43,7 +43,8 @@ impl From<TargetSpec> for Target {
             onwards_model: value.onwards_model,
             limiter: value.rate_limit.map(|rl| {
                 Arc::new(governor::RateLimiter::direct(
-                    Quota::per_second(rl.requests_per_second).allow_burst(rl.burst_size),
+                    Quota::per_second(rl.requests_per_second)
+                        .allow_burst(rl.burst_size.unwrap_or(rl.requests_per_second)),
                 )) as Arc<dyn RateLimiter>
             }),
         }


### PR DESCRIPTION
This PR adds rate limit functionality, + structured errors. It also: 

1. Removes the ability to set the Onwards-Model header. This was a security hole, since it meant if we knew a model name (and had access to another model), we could use the onwards model header to get to the unauthorized target from the authorized one
2. Adds structured errors
3. Adds the ability to set rate limits per target using the `governor` crate (~ leaky bucket rate limiting). Two new parameters: 
 - `requests_per_second` (the rate the bucket fill)
- `burst_size`(optional) (the maximum size of the bucket. Defaults to requests per second). 
