### PR TITLE
feat: add body transformation with path parameter

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -33,6 +33,15 @@ pub async fn target_message_handler<T: HttpClient>(
                                                                     // this should never fail.
         };
 
+    // Apply body transformation if provided
+    if let Some(ref transform_fn) = state.body_transform_fn {
+        let path = req.uri().path();
+        if let Some(transformed_body) = transform_fn(path, req.headers(), &body_bytes) {
+            debug!("Applied body transformation for path: {}", path);
+            body_bytes = transformed_body;
+        }
+    }
+
     // Log full incoming request details for debugging
     trace!(
         "Incoming request details:\n  Method: {}\n  URI: {}\n  Headers: {:?}\n  Body: {}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1134,6 +1134,7 @@ mod tests {
 
         let targets = target::Targets {
             targets: targets_map,
+            key_rate_limiters: Arc::new(DashMap::new()),
         };
 
         // Create a body transformation function that adds a "transformed": true field
@@ -1191,6 +1192,7 @@ mod tests {
 
         let targets = target::Targets {
             targets: targets_map,
+            key_rate_limiters: Arc::new(DashMap::new()),
         };
 
         let mock_client = MockHttpClient::new(StatusCode::OK, r#"{"success": true}"#);
@@ -1236,6 +1238,7 @@ mod tests {
 
         let targets = target::Targets {
             targets: targets_map,
+            key_rate_limiters: Arc::new(DashMap::new()),
         };
 
         // Create a transformation function that always returns None (no transformation)
@@ -1283,6 +1286,7 @@ mod tests {
 
         let targets = target::Targets {
             targets: targets_map,
+            key_rate_limiters: Arc::new(DashMap::new()),
         };
 
         // Create a transformation function that forces include_usage for streaming requests
@@ -1355,6 +1359,7 @@ mod tests {
 
         let targets = target::Targets {
             targets: targets_map,
+            key_rate_limiters: Arc::new(DashMap::new()),
         };
 
         // Create the same transformation function
@@ -1425,6 +1430,7 @@ mod tests {
 
         let targets = target::Targets {
             targets: targets_map,
+            key_rate_limiters: Arc::new(DashMap::new()),
         };
 
         // Create a transformation function that only transforms specific paths


### PR DESCRIPTION
When using onwards as a library, its useful to be able to transform the request body. This provides for that.