### PR TITLE
feat: add response headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,7 @@ disable, set the `--watch` flag to false).
 - `rate_limit`: Configuration for per-target rate limiting (optional)
   - `requests_per_second`: Number of requests allowed per second
   - `burst_size`: Maximum burst size of requests
-- `pricing`: Configuration for token pricing (optional)
-  - `input_price_per_token`: Price per input token
-  - `output_price_per_token`: Price per output token
+- `response_header`: Key-value pairs to add or override headers in the response (optional)
 
 ## Usage
 
@@ -439,11 +437,13 @@ curl -X POST http://localhost:3000/v1/chat/completions \
   -d '{"model": "gpt-4", "messages": [{"role": "user", "content": "Hello!"}]}'
 ```
 
-## Pricing Information
+## Response Headers
 
-Onwards can include token-based pricing information in the response extensions. This allows downstream applications to take action on usage of each request. This is configured per-target.
+Onwards can include custom headers in the response, these can override existing headers or add new ones.
 
-This means that if you have a dynamic token price when a user's request is accepted the price is then agreed and recorded in the request/response.
+### Pricing
+
+One use of this feature is to set pricing information. This means that if you have a dynamic token price when a user's request is accepted the price is then agreed and can be recorded in the HTTP headers.
 
 Add pricing information to any target in your `config.json`:
 
@@ -453,13 +453,10 @@ Add pricing information to any target in your `config.json`:
     "priced-model": {
       "url": "https://api.provider.com",
       "key": "your-api-key",
-      "pricing": {
-        "input_price_per_token": 0.0001,
-        "output_price_per_token": 0.0002
+      "response_headers": {
+        "Input-Price-Per-Token": "0.0001",
+        "Output-Price-Per-Token": "0.0002"
       }
-    }
-  }
-}
 ```
 
 ## Testing

--- a/src/target.rs
+++ b/src/target.rs
@@ -24,27 +24,6 @@ pub struct RateLimitParameters {
     pub burst_size: Option<NonZeroU32>,
 }
 
-/// Pricing information for token-based billing
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct TokenPricing {
-    /// Price per input token (e.g., 0.00003 for $0.03 per 1K tokens)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub input_price_per_token: Option<f64>,
-
-    /// Price per output token (e.g., 0.00006 for $0.06 per 1K tokens)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub output_price_per_token: Option<f64>,
-}
-
-impl TokenPricing {
-    /// Calculate cost for a given number of input and output tokens
-    pub fn calculate_cost(&self, input_tokens: u64, output_tokens: u64) -> f64 {
-        let input_cost = self.input_price_per_token.unwrap_or(0.0) * (input_tokens as f64);
-        let output_cost = self.output_price_per_token.unwrap_or(0.0) * (output_tokens as f64);
-        input_cost + output_cost
-    }
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize, Builder)]
 pub struct TargetSpec {
     pub url: Url,
@@ -57,9 +36,9 @@ pub struct TargetSpec {
     #[serde(default)]
     pub upstream_auth_header_prefix: Option<String>,
 
-    /// Token-based pricing information for billing/credits
+    /// Custom headers to include in responses (e.g., pricing, metadata)
     #[serde(default)]
-    pub pricing: Option<TokenPricing>,
+    pub response_headers: Option<HashMap<String, String>>,
 }
 
 /// Normalizes a URL to ensure it has a trailing slash
@@ -91,7 +70,7 @@ impl From<TargetSpec> for Target {
             }),
             upstream_auth_header_name: value.upstream_auth_header_name,
             upstream_auth_header_prefix: value.upstream_auth_header_prefix,
-            pricing: value.pricing,
+            response_headers: value.response_headers,
         }
     }
 }
@@ -124,8 +103,8 @@ pub struct Target {
     pub limiter: Option<Arc<dyn RateLimiter>>,
     pub upstream_auth_header_name: Option<String>,
     pub upstream_auth_header_prefix: Option<String>,
-    /// Token-based pricing information
-    pub pricing: Option<TokenPricing>,
+    /// Custom headers to include in responses (e.g., pricing, metadata)
+    pub response_headers: Option<HashMap<String, String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
This adds a configurable response headers to a target. One application is setting pricing information for a request. When a request is sent off to the downstream the price is locked in and is added to the response headers. This enables downstream processors to the AI model to action on the request with the token price exactly when the request was accepted for processing.