### PR TITLE
feat: session affinity for model-based provider selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,6 +269,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bon"
 version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +421,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,6 +443,16 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "darling"
@@ -507,6 +535,16 @@ name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "displaydoc"
@@ -729,6 +767,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -826,13 +874,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
-name = "http"
-version = "1.3.1"
+name = "hex"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -1440,15 +1493,18 @@ dependencies = [
  "dashmap",
  "futures-util",
  "governor",
+ "hex",
  "http-body-util",
  "hyper",
  "hyper-tls",
  "hyper-util",
+ "metrics",
  "notify",
  "rand",
  "rstest",
  "serde",
  "serde_json",
+ "sha2",
  "subtle",
  "tokio",
  "tokio-stream",
@@ -1945,6 +2001,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2221,9 +2288,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags 2.9.1",
  "bytes",
@@ -2318,6 +2385,12 @@ name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "typetag"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,9 @@ subtle = "2.6.1"
 axum-prometheus = "0.10.0"
 governor = "0.10.1"
 rand = "0.9"
+hex = "0.4.3"
+sha2 = "0.10.9"
+metrics = "0.24.3"
 
 [dev-dependencies]
 axum-test = "18.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,6 @@ governor = "0.10.1"
 rand = "0.9"
 hex = "0.4.3"
 sha2 = "0.10.9"
-metrics = "0.24.3"
 
 [dev-dependencies]
 axum-test = "18.0.0"

--- a/docs/MODEL_SESSION_AFFINITY_DESIGN.md
+++ b/docs/MODEL_SESSION_AFFINITY_DESIGN.md
@@ -1,0 +1,1013 @@
+# Model Session Affinity Design
+
+## Summary
+
+This document proposes a v1 session affinity design for model-based provider selection in Onwards.
+
+The goal is to keep requests for the same logical session on the same upstream provider for the same requested model alias during a configurable TTL window.
+
+Session input resolution in v1 uses this precedence:
+
+1. read explicit client-provided `session_id` if present
+2. read `Authorization` if present
+3. derive the final session fingerprint from the composition rules below
+
+The primary use case is upstream cache affinity for chat-style workloads:
+
+- prompt cache locality
+- KV cache locality
+- warm conversational context on the same backend
+- avoiding unnecessary cache misses caused by provider hopping
+
+The design preserves existing authentication, routing rules, rate limiting, concurrency limits, strict-mode validation, and fallback behavior.
+
+## Implementation Status
+
+The design in this document is now implemented in the current codebase with the following scope:
+
+- pool-level `session_affinity` config is supported
+- session identity is derived from configured session header and/or `Authorization: Bearer`
+- provider identity is hashed and cached on `Provider`
+- affinity applies to all model-routed requests that pass through `target_message_handler`
+- fallback can optionally rebind according to `rebind_on_fallback`
+- request-path lazy stale cleanup is implemented
+- single-process hot reload eager cleanup is implemented for the default in-memory store
+- Prometheus counters are emitted for affinity result and reload cleanup events
+
+Current implementation files:
+
+- `src/session_affinity/mod.rs`
+- `src/session_affinity/context.rs`
+- `src/session_affinity/key.rs`
+- `src/session_affinity/store.rs`
+- `src/session_affinity/metrics.rs`
+- `src/handlers.rs`
+- `src/load_balancer.rs`
+- `src/target.rs`
+- `src/main.rs`
+
+## Current State
+
+Today, provider selection is purely pool-based:
+
+1. Extract `model` from header or request body.
+2. Resolve the model alias to a `ProviderPool`.
+3. Apply auth, routing rules, rate limits, and concurrency limits.
+4. Select a provider using `ProviderPool::select_iter()`.
+5. Retry on fallback conditions if configured.
+
+Relevant code:
+
+- `src/handlers.rs`: `target_message_handler`
+- `src/load_balancer.rs`: `ProviderPool`, `select()`, `select_iter()`
+- `src/strict/handlers.rs`: validated requests are forwarded into the same handler path
+- `src/target.rs`: config loading and hot reload
+
+There is currently no persistent binding from `(model alias, session identity)` to a provider.
+
+## Problem Statement
+
+Some clients can provide a stable `session_id`, but many OpenAI-compatible clients do not.
+
+In practice, the proxy already has another stable signal: `Authorization: Bearer <token>`.
+
+If the same logical session repeatedly hits the same model alias within a short time window, forwarding those requests to the same upstream provider can materially improve cache hit rates and reduce latency variance.
+
+## Goals
+
+- Support session affinity for any request that selects a provider via model alias.
+- Enable affinity per model alias, not globally.
+- Prefer explicit `session_id` as the session discriminator when provided by the client.
+- Fold `Authorization` into the fingerprint whenever it is available so affinity stays scoped to the caller boundary.
+- Preserve current behavior when affinity is not configured and when neither `session_id` nor `Authorization` is available.
+- Work in both passthrough mode and strict mode.
+- Interoperate correctly with fallback and provider hot reload.
+- Keep the design compatible with single-instance and multi-instance deployments.
+
+## Non-Goals
+
+- Affinity for requests that do not resolve a model alias.
+- Inferring identity from request payload content.
+- Cross-model affinity. Bindings are scoped to one requested model alias.
+- Durable conversation state management. This is routing affinity, not transcript storage.
+- Perfect per-end-user affinity when multiple real users share one API key and no explicit `session_id` is provided.
+
+## Design Position
+
+### Affinity overlay, not a new strategy
+
+Although the user-visible behavior may look like a load balancing strategy, affinity should not replace `weighted_random` or `priority`.
+
+Affinity is better modeled as an overlay on top of existing selection:
+
+1. If a valid binding exists, prefer the bound provider.
+2. Otherwise, use the existing pool strategy to choose a provider.
+
+This keeps the current load balancing semantics intact for first selection and fallback selection.
+
+Concretely, provider selection becomes two-phase:
+
+1. normal selection path: existing `strategy` and `fallback`
+2. session-aware selection path: reuse an existing binding if one exists, otherwise delegate to the normal path
+
+This separation keeps the feature easy to reason about and aligns with proven designs used in other projects.
+
+### Pool-level opt-in
+
+Affinity should be configured on the `PoolSpec` for a model alias. This keeps the feature local to aliases that benefit from cache affinity.
+
+### Session identity with fallback
+
+The proxy should prefer an explicit client-provided session identifier when available.
+
+When the client does not provide one, the proxy should fall back to bearer-token-derived identity.
+
+This matches current integration reality:
+
+- supports clients that already have first-class session semantics
+- requires no client-side protocol change when they do not
+- aligns with the current auth flow
+- gives stable affinity per session and per model alias
+
+### Affinity must stay within auth boundaries
+
+Session affinity should not allow one caller to steer itself into another caller's affinity bucket simply by guessing a `session_id`.
+
+Recommended v1 rule:
+
+- if `session_id` exists and `Authorization` exists, fingerprint both together
+- if only `session_id` exists, fingerprint `session_id` alone
+- if only `Authorization` exists, fingerprint `Authorization` alone
+
+This keeps explicit session affinity scoped within the caller's auth boundary when auth is available, which is important for multi-tenant deployments.
+
+### Affinity is best-effort
+
+If the bound provider is unavailable, removed by config reload, at concurrency capacity, or rejected by local fallback policy, the request should still proceed through normal provider selection.
+
+### Rebinding happens after successful takeover
+
+The binding should only move to a new provider after that provider successfully handles the request.
+
+## Proposed Configuration
+
+Add pool-level configuration in `src/target.rs`:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SessionAffinityConfig {
+    #[serde(default = "default_session_affinity_header_name")]
+    pub header_name: String,
+
+    #[serde(default = "default_session_affinity_ttl_secs")]
+    pub ttl_secs: u64,
+
+    #[serde(default = "default_session_affinity_rebind_on_fallback")]
+    pub rebind_on_fallback: bool,
+}
+```
+
+Add to `PoolSpec`:
+
+```rust
+#[serde(default)]
+pub session_affinity: Option<SessionAffinityConfig>,
+```
+
+Suggested defaults:
+
+- `header_name = "x-session-id"`
+- `ttl_secs = 300`
+- `rebind_on_fallback = true`
+
+Enablement rule:
+
+- `session_affinity` absent: disabled
+- `session_affinity` present: enabled
+
+First-version scope:
+
+- the explicit session id is read from a configured header
+- `Authorization` is used as a fallback identity source and as a caller boundary when present
+- no per-pool capacity tuning is configurable yet
+- no separate affinity strategy enum is introduced
+
+Example:
+
+```json
+{
+  "targets": {
+    "gpt-4o": {
+      "strategy": "weighted_random",
+      "fallback": {
+        "enabled": true,
+        "on_status": [429, 5],
+        "on_rate_limit": true
+      },
+      "session_affinity": {
+        "header_name": "x-session-id",
+        "ttl_secs": 300,
+        "rebind_on_fallback": true
+      },
+      "providers": [
+        { "url": "https://api.openai.com", "onwards_key": "sk-a", "weight": 3 },
+        { "url": "https://api.openai.com", "onwards_key": "sk-b", "weight": 1 }
+      ]
+    }
+  }
+}
+```
+
+## Configuration Validation
+
+`session_affinity` should be validated at config load time.
+
+Required validation rules:
+
+- `header_name` must be non-empty after trimming
+- `ttl_secs` must be greater than zero
+- the pool must still contain at least one selectable provider
+
+Normalization rules:
+
+- trim `header_name`
+- normalize `header_name` to lowercase at config load time
+- use the normalized value at request time
+
+Recommended implementation:
+
+```rust
+#[serde(deserialize_with = "deserialize_lowercase")]
+pub header_name: String,
+```
+
+This keeps runtime request handling simple and avoids repeated case normalization.
+
+Advisory validation:
+
+- if `ttl_secs > 3600`, emit a warning because long TTLs may increase memory pressure and reduce rebalance responsiveness
+- if `rebind_on_fallback = false`, emit an informational log because sessions may remain sticky to a degraded original provider
+
+Failing fast at config load time is preferable to silently disabling affinity at runtime.
+
+## Provider Identity
+
+Affinity mappings must not depend on provider index in the pool because provider order can change on config reload.
+
+For v1, provider identity should remain an internal implementation detail.
+
+At load time, derive a deterministic provider identity from:
+
+- `url`
+- `onwards_key`
+- `onwards_model`
+
+The runtime affinity mapping should store `provider_id`, not provider index.
+
+The identity should be computed by hashing structured inputs rather than concatenating raw strings.
+
+Recommended v1 approach:
+
+```rust
+fn compute_provider_id(target: &Target) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(target.url.as_str().as_bytes());
+    hasher.update(b"|");
+    hasher.update(target.onwards_key.as_deref().unwrap_or("").as_bytes());
+    hasher.update(b"|");
+    hasher.update(target.onwards_model.as_deref().unwrap_or("").as_bytes());
+    hex::encode(hasher.finalize())[..16].to_string()
+}
+```
+
+Notes:
+
+- do not expose raw `onwards_key` in logs, metrics, or debug output
+- hashing avoids leaking secrets through identity construction
+- a short stable digest is sufficient as an internal provider identifier
+- the computed identity should be cached on `Provider` at construction time, not recomputed on the request hot path
+- explicit separators prevent accidental ambiguity between adjacent fields
+
+Suggested shape:
+
+```rust
+pub struct Provider {
+    target: Target,
+    weight: u32,
+    limiter: ConcurrencyLimiter,
+    identity: String,
+}
+
+impl Provider {
+    pub fn identity(&self) -> &str {
+        &self.identity
+    }
+}
+```
+
+## Affinity Key
+
+The affinity binding key should be:
+
+```text
+(requested_model_alias, session_fingerprint)
+```
+
+The value is:
+
+```text
+provider_id
+```
+
+Where:
+
+- `requested_model_alias` is the model name requested by the client
+- `session_fingerprint` is derived from either explicit `session_id` or `Authorization`
+
+The mapping must use the client-requested model alias, not the provider-rewritten `onwards_model`.
+
+## Session Identity Resolution
+
+V1 uses the following steps to derive session input:
+
+1. Read the configured session header and treat a non-empty value as `session_id`.
+2. Read `Authorization: Bearer <token>` and treat a valid bearer token as `authorization`.
+3. If neither exists, affinity is skipped.
+
+This keeps the feature named `session affinity` while still supporting clients that do not explicitly send a session id.
+
+Header handling requirements:
+
+- HTTP header names are case-insensitive
+- `header_name` should be normalized once during config loading
+- request handling should not perform repeated header-name normalization on every request
+- empty or whitespace-only session header values should be treated as missing
+- if multiple values are present for the same header, use the effective value returned by the HTTP framework and verify that behavior in tests
+- bearer token extraction should treat the `Bearer` scheme case-insensitively
+- leading and trailing whitespace around the extracted token should be trimmed
+- non-`Bearer` authorization schemes should be ignored for affinity fallback
+
+## Fingerprinting
+
+Raw `session_id` and raw bearer tokens should not be used directly in logs, metrics, or cache keys exposed outside process memory.
+
+Recommended v1 approach:
+
+```text
+session_fingerprint = SHA256(session_identity)
+```
+
+Recommended composition rule:
+
+```text
+if session_id and authorization:
+    session_identity = authorization + "|" + session_id
+else if session_id:
+    session_identity = session_id
+else if authorization:
+    session_identity = authorization
+```
+
+This composition rule is normative for v1. The proxy must not treat `session_id` as a globally sufficient affinity key when `Authorization` is also available.
+
+Requirements:
+
+- deterministic for the same identity
+- non-reversible in operational surfaces
+- safe to use as an in-memory or external-store key
+
+V1 should not introduce a separate HMAC secret configuration.
+
+## Runtime State
+
+Add a shared store to `AppState`:
+
+```rust
+pub session_affinity_store: Arc<dyn SessionAffinityStore>
+```
+
+Suggested trait:
+
+```rust
+pub trait SessionAffinityStore: Send + Sync {
+    fn get(&self, key: &AffinityKey) -> Option<AffinityEntry>;
+    fn insert(&self, key: AffinityKey, entry: AffinityEntry, ttl: Duration);
+    fn delete(&self, key: &AffinityKey);
+    fn touch(&self, key: &AffinityKey, ttl: Duration);
+    fn remove_stale_for_model(
+        &self,
+        model: &str,
+        valid_provider_ids: &HashSet<String>,
+    ) -> usize {
+        0
+    }
+}
+
+pub struct AffinityKey {
+    pub model: String,
+    pub session_fingerprint: String,
+}
+
+pub struct AffinityEntry {
+    pub provider_id: String,
+}
+```
+
+The store API should stay intentionally small:
+
+- normal selection remains in `ProviderPool`
+- affinity state remains in the store
+- selection orchestration remains in the handler
+
+This avoids coupling session state to the load balancer implementation.
+
+V1 note:
+
+- `touch()` is preferred over a dedicated `get_and_refresh()` API because it keeps the store interface small and works for both in-memory caches and external stores
+- returning owned values is acceptable for v1 because provider ids are small; avoiding extra lifetime complexity is preferable here
+- `AffinityEntry` intentionally does not expose TTL or expiration time; expiration remains a store implementation detail
+- `touch(ttl)` refreshes TTL only when the key already exists
+- `touch()` on a missing key is a silent no-op
+- `remove_stale_for_model()` is optional for store implementations; the default no-op is suitable for shared external stores that prefer lazy cleanup only
+
+Expected store behavior:
+
+| Scenario | Expected behavior |
+|----------|-------------------|
+| `get()` finds an expired entry | Return `None`; cleanup may be eager or lazy |
+| `insert()` on an existing key | Overwrite `provider_id` and refresh TTL |
+| `delete()` on a missing key | Succeed silently |
+| `touch()` on a missing key | Succeed silently with no creation |
+| `remove_stale_for_model()` on unsupported store | Return `0` and leave cleanup to lazy lookup |
+
+Single-instance implementation:
+
+- in-memory TTL cache such as `moka::sync::Cache`, or `DashMap` plus cleanup
+
+Multi-instance implementation:
+
+- Redis or another shared external store
+
+V1 should treat store capacity as an implementation detail of the default in-memory store, not as a per-pool config knob.
+
+Current implementation note:
+
+- the default in-memory store uses `DashMap`
+- expired entries are evicted lazily on `get()`
+- successful affinity reuse refreshes TTL via `touch(ttl)`
+- hot reload can eagerly remove stale provider bindings for the in-memory store
+- there is no background sweeper yet for expired entries; expiration remains lazy by default
+
+## Applicability
+
+If a model pool has `session_affinity` configured, affinity should apply to all requests that:
+
+- resolve a model alias for provider selection
+- route through the standard provider selection path
+
+This includes:
+
+- `/v1/chat/completions`
+- `/v1/responses` when the request resolves a model
+- `/v1/completions`
+- `/v1/embeddings`
+- other model-based passthrough routes supported by the proxy
+
+This does not include:
+
+- requests that do not resolve a model
+- endpoints that bypass model-based provider selection
+
+Chat completions remain the primary motivation, but the routing behavior should be consistent for the entire model pool once `session_affinity` is enabled.
+
+## Request Flow
+
+The affinity logic should live in the provider selection layer, not in a special-case route branch.
+
+Proposed flow for any model-routed request:
+
+1. Extract `model` as today.
+2. Resolve pool and apply auth, routing rules, rate limits, and pool/key concurrency checks as today.
+3. If `session_affinity` is not configured for the pool, skip affinity.
+4. Read the configured session header as optional `session_id`.
+5. Read `Authorization` as optional bearer token.
+6. If neither exists, skip affinity and continue with the existing pool strategy.
+7. Compute `session_fingerprint` using the composition rule:
+   - `authorization + "|" + session_id` when both exist
+   - `session_id` when only session id exists
+   - `authorization` when only authorization exists
+8. Construct `AffinityKey { model, session_fingerprint }`.
+9. Look up the key in the affinity store.
+10. If a bound provider exists and is still present in the current pool:
+   - try that provider first
+   - if it is at provider concurrency capacity, unavailable, or locally rate-limited, continue to normal selection
+11. If no valid binding exists, use the existing pool selection logic.
+12. If a provider successfully handles the request:
+   - first bind via `insert(key, entry, ttl)`
+   - successful reuse of the same bound provider can refresh TTL via `touch(key, ttl)`
+   - successful fallback takeover can rebind via `insert(key, entry, ttl)` when allowed
+13. If fallback selects a different provider and that provider succeeds:
+   - rebind according to `rebind_on_fallback`
+
+Affinity should only run after the request has passed existing authentication checks. It is not an authentication primitive.
+When explicit `session_id` is present, it only affects routing stickiness and does not replace auth.
+
+Concurrency note:
+
+- preferred-provider selection must attempt to acquire the provider's concurrency guard first
+- only if guard acquisition fails should the request fall back to normal selection
+- once guard acquisition succeeds, the provider choice for that attempt is fixed
+
+If the same session issues concurrent requests, races are acceptable as long as:
+
+- each individual request selects a valid provider
+- the final stored binding is one of the successfully used providers
+- the store remains internally consistent
+
+Provider existence checks should use a pool helper such as:
+
+```rust
+impl ProviderPool {
+    pub fn get_provider_by_id(&self, provider_id: &str) -> Option<(usize, &Provider)> {
+        self.providers
+            .iter()
+            .enumerate()
+            .find(|(_, provider)| provider.identity() == provider_id)
+    }
+}
+```
+
+## Load Balancer Changes
+
+`ProviderPool` should expose affinity-aware selection instead of forcing handler-level provider iteration.
+
+Suggested additions in `src/load_balancer.rs`:
+
+```rust
+pub fn select_by_provider_id(
+    &self,
+    provider_id: &str,
+    exclude: &HashSet<usize>,
+) -> Option<(usize, &Target, ConcurrencyGuard)>;
+
+pub fn select_iter_with_preferred(
+    &self,
+    preferred_provider_id: Option<&str>,
+) -> SelectIter<'_>;
+```
+
+Behavior:
+
+- if `preferred_provider_id` is provided and the provider is selectable, the iterator yields it first
+- remaining attempts follow normal `strategy` and `fallback` behavior
+- provider-level concurrency and local rate-limit checks still apply
+
+This keeps affinity layered on top of the current load balancing strategy rather than replacing it.
+
+An important implementation property is to preserve two explicit entry points:
+
+- normal provider selection
+- provider selection with a preferred bound provider
+
+That keeps the code path clear and mirrors the strongest idea from external reference designs without inheriting their tighter coupling to a specific selector implementation.
+
+`SelectIter` likely needs explicit preferred-provider state, for example:
+
+```rust
+pub struct SelectIter<'a> {
+    pool: &'a ProviderPool,
+    excluded: HashSet<usize>,
+    max_attempts: usize,
+    attempts: usize,
+    with_replacement: bool,
+    preferred: Option<usize>,
+    preferred_tried: bool,
+}
+```
+
+Expected `next()` behavior:
+
+1. if `preferred` exists and has not yet been tried, attempt it first
+2. if preferred selection fails, mark it as tried
+3. all later attempts use the existing selection strategy
+
+Additional rules:
+
+- if `preferred` is already in `excluded`, treat it as already tried
+- attempting `preferred` consumes one attempt, just like any other provider attempt
+- once `preferred_tried` becomes true, it must not be revisited by the iterator
+
+## Final Config Shape
+
+For the first implementation, the configuration surface should be:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SessionAffinityConfig {
+    #[serde(default = "default_session_affinity_header_name")]
+    pub header_name: String,
+
+    #[serde(default = "default_session_affinity_ttl_secs")]
+    pub ttl_secs: u64,
+
+    #[serde(default = "default_session_affinity_rebind_on_fallback")]
+    pub rebind_on_fallback: bool,
+}
+```
+
+Attached at pool level:
+
+```rust
+pub struct PoolSpec {
+    // existing fields...
+    #[serde(default)]
+    pub session_affinity: Option<SessionAffinityConfig>,
+}
+```
+
+Semantics:
+
+- absence of `session_affinity` means affinity is disabled
+- presence of `session_affinity` means affinity is enabled for that model alias
+- the configured header provides the explicit session discriminator
+- `Authorization` is folded into the fingerprint whenever it exists
+- TTL uses sliding expiration
+- store capacity is an implementation detail of the default in-memory store
+
+This is the recommended final v1 config because it is minimal, directly implementable, and does not expose extension points that the first release will not support.
+
+## Handler Integration
+
+The main integration point is `target_message_handler` in `src/handlers.rs`.
+
+The handler already owns:
+
+- model extraction
+- request header access
+- bearer token extraction
+- pool resolution
+- routing rules
+- rate limiting
+- request forwarding
+- fallback loop
+
+Affinity should be inserted after pool resolution and policy checks, but before provider iteration.
+
+High-level integration:
+
+1. Resolve the affinity config from the selected pool.
+2. Build a `SessionContext` by reading the configured session header and falling back to bearer token extraction.
+3. Compute the session fingerprint once and reuse it for routing, logs, and metrics.
+4. Pass the preferred provider id into the pool selection iterator.
+5. On successful upstream selection and request completion, update the mapping.
+
+Because strict handlers call into `target_message_handler`, no separate affinity implementation is needed for strict mode.
+
+This also means the affinity behavior is naturally backward compatible:
+
+- models without `session_affinity` keep existing behavior
+- requests without session identity keep existing behavior
+- existing load balancing strategies continue to work unchanged
+
+Suggested helper types:
+
+```rust
+pub struct SessionContext {
+    pub fingerprint: String,
+    pub source: SessionSource,
+}
+
+pub enum SessionSource {
+    HeaderOnly,
+    AuthorizationOnly,
+    HeaderAndAuthorization,
+    None,
+}
+```
+
+## Fallback Semantics
+
+Fallback behavior needs explicit rules or the affinity mapping will flap.
+
+### Recommended semantics
+
+- if the bound provider succeeds, keep the binding
+- if the bound provider is locally unavailable for selection, temporarily bypass it for the current request and keep the old binding unless another provider successfully takes over and `rebind_on_fallback = true`
+- if the bound provider fails and another provider is attempted but does not succeed, keep the old binding
+- if another provider succeeds via fallback, update the binding to that provider when `rebind_on_fallback = true`
+- if the bound provider is removed from config or no longer exists in the pool, discard the stale mapping and select normally
+
+Explicit v1 decision:
+
+- if a fallback request succeeds and rebinding occurs, the proxy does not automatically switch the session back to the original provider later
+- returning to the original provider only happens if the current binding expires or a future successful fallback rebinds again
+- no `rebind_cooldown_secs` is introduced in v1; if flapping appears in production, it should be added later based on observed behavior
+
+### Why this matters
+
+Updating the binding too early causes session churn under transient errors. Not updating it after successful takeover causes repeated attempts to a bad provider.
+
+## TTL Semantics
+
+Use sliding expiration:
+
+- every successful request refreshes the TTL
+- active sessions remain sticky
+- inactive sessions age out naturally
+
+Recommended initial value:
+
+- `ttl_secs = 300` or `600`
+
+Long TTLs improve cache locality but reduce rebalancing flexibility. Short TTLs preserve balance but weaken cache affinity.
+
+## Concurrency and Streaming
+
+### Concurrency
+
+Affinity does not bypass existing pool-level or provider-level concurrency controls.
+
+If the bound provider is full:
+
+- prefer temporary fallback for the current request
+- do not immediately rewrite the mapping unless the fallback provider successfully completes the request and rebind policy allows it
+
+Tradeoff:
+
+- immediate fallback is simple and keeps latency low
+- in cache-sensitive workloads, immediate fallback may reduce cache hit rate and cause session flapping across providers
+
+Future optimization:
+
+- a bounded affinity wait such as `max_wait_ms` could allow short waiting on the bound provider before falling back
+- v1 intentionally does not introduce queueing semantics at the affinity layer
+
+### Streaming
+
+Streaming requests should behave the same as non-streaming requests:
+
+- provider choice is made once, before the upstream request is sent
+- the stream remains on that provider for the lifetime of the request
+- the affinity mapping can be refreshed as soon as the request has been accepted by the selected provider
+
+V1 decision:
+
+- refreshing TTL when the upstream accepts the HTTP request is acceptable
+
+Future optimization:
+
+- for streaming requests, TTL refresh could instead be delayed until the first valid upstream chunk is observed
+- this would reduce the chance of extending affinity for a provider that accepts the connection but fails before meaningful output begins
+
+V1 does not add this extra complexity.
+
+## Hot Reload Semantics
+
+Today, config reload preserves active connection counters but not affinity state.
+
+That is acceptable only if the affinity store lives outside `Targets`.
+
+Recommended approach:
+
+- keep affinity state in `AppState`, not in `Targets`
+- on each request, validate that the stored `provider_id` still exists in the current pool
+- if it does not exist, delete the stale mapping and fall back to normal selection
+
+Implemented single-process optimization:
+
+- the default in-memory store participates in eager stale cleanup after successful config reload
+- cleanup is model-scoped and removes bindings whose `provider_id` is no longer valid in the new local pool view
+- deleted models are also cleaned if they previously had affinity-enabled pools
+- request-path lazy validation remains the correctness fallback even when eager cleanup runs
+
+Distributed deployment rule:
+
+- when using an external shared store such as Redis across multiple gateway instances, use lazy cleanup only
+- avoid eager cleanup during config reload in shared-store mode because different instances may observe the new provider set at slightly different times
+- stale bindings should only be removed when the current instance validates that the bound provider no longer exists in its active pool view
+
+This keeps affinity stable across config reloads while remaining robust to provider removal or identity changes.
+
+## Deployment Modes
+
+### Single instance
+
+Use an in-memory TTL cache. This is the simplest implementation and likely sufficient for development or a single gateway node.
+
+### Multiple gateway instances
+
+Use a shared external store. Otherwise the same logical session may hit different gateway replicas and receive different provider bindings.
+
+For multi-instance deployments, session affinity should be considered incomplete unless:
+
+- requests are already pinned to one gateway instance by an outer load balancer, or
+- the affinity store is externalized
+
+## Observability
+
+Add logs and metrics for:
+
+- affinity lookup hit
+- affinity lookup miss
+- stale mapping detected
+- bound provider unavailable
+- fallback from bound provider
+- successful rebind
+- reload-time stale cleanup
+
+Suggested metric dimensions:
+
+- `model`
+- `result`
+
+Suggested counters or events:
+
+- total affinity lookups
+- affinity hit ratio
+- rebind count
+- stale-binding eviction count
+- fallback-after-affinity count
+
+Current metric set for `session_affinity_total{model, result}`:
+
+- `hit`
+- `miss`
+- `stale`
+- `bound`
+- `rebound`
+- `unavailable`
+- `error`
+- `fallback_no_rebind`
+
+Definitions:
+
+- `hit`: affinity binding existed and the bound provider was selected
+- `miss`: no affinity binding existed
+- `stale`: affinity binding existed but pointed to a provider no longer valid in the current pool
+- `bound`: no prior binding existed and the request successfully created one
+- `rebound`: a different provider succeeded and the binding was updated
+- `unavailable`: the bound provider existed but could not be selected locally, for example due to concurrency or local rate limits
+- `error`: the bound provider was selected but failed at the upstream interaction stage
+- `fallback_no_rebind`: fallback succeeded but the binding was intentionally preserved because `rebind_on_fallback = false`
+
+Cleanup metrics:
+
+- `session_affinity_cleanup_total{model, reason="reload"}`
+
+Do not emit raw `session_id`, raw bearer tokens, derived fingerprints, or `provider_id` as metric labels.
+
+Reasoning:
+
+- `provider_id` is safe enough for targeted debug logging if needed
+- `provider_id` should still stay out of metric labels in v1 to keep cardinality low and metrics stable
+- separate `unavailable` from `error` makes it easier to distinguish local selection failure from upstream failure after affinity hit
+- `bound` distinguishes first-write success from ordinary misses
+- cleanup is tracked separately because it is driven by config reload rather than request selection outcome
+
+## External Reference Notes
+
+The design is informed by ideas seen in other projects that support multi-key or multi-upstream session stickiness.
+
+The most useful ideas to keep are:
+
+- session binding should be configured independently from the base selection strategy
+- the implementation should expose both a normal selection path and a session-aware selection path
+- TTL and expiration behavior should be explicit
+- validation and testing should be part of the design, not an afterthought
+
+The ideas intentionally not adopted are:
+
+- exposing a broad `source = auto` style configuration in v1
+- coupling affinity state directly into a selector-specific in-memory map
+- replacing the existing load balancing strategy with a dedicated affinity strategy
+
+This keeps the design aligned with Onwards' current architecture, where provider selection, fallback, and config reload are already more sophisticated than a simple multi-key round-robin selector.
+
+## Risks and Tradeoffs
+
+### Authorization fallback is not always a real end-user identity
+
+If many users share one API key and no explicit `session_id` is provided, the affinity behavior is effectively per key, not per end user.
+
+This is acceptable for cache affinity, but the semantic scope must be documented clearly.
+
+### Explicit session id alone can be unsafe in multi-tenant deployments
+
+If explicit `session_id` were used as the sole affinity input even when `Authorization` is present, different callers could intentionally or accidentally collide onto the same affinity bucket.
+
+V1 avoids this by folding `Authorization` into the fingerprint whenever both values are present.
+
+### Affinity can create hotspots
+
+High-throughput sessions may stick to one provider and reduce balance quality. This is an intentional tradeoff in exchange for higher cache hit rates.
+
+### Missing session identity disables affinity
+
+That is acceptable. Requests should degrade to the current routing behavior.
+
+### Provider identity changes invalidate bindings
+
+Changing a provider's `url`, `onwards_key`, or `onwards_model` changes its derived identity.
+
+This invalidates bindings for sessions previously attached to that provider and can cause a temporary cache miss wave after config reload.
+
+V1 accepts this tradeoff because identity changes may represent a materially different upstream target or account boundary.
+
+## Testing Plan
+
+Add tests covering:
+
+1. first request with explicit `session_id` creates a binding
+2. subsequent request with same `(model, session_id)` reuses the same provider
+3. missing `session_id` falls back to `Authorization`
+4. same `(model, authorization)` reuses the same provider when no `session_id` is present
+5. different explicit session ids can route to different providers
+6. missing both `session_id` and `Authorization` preserves existing load balancing behavior
+7. the same affinity behavior applies to `/chat/completions`, `/responses`, `/completions`, and `/embeddings` when they resolve the same model alias
+8. bound provider removed on config reload causes lazy rebinding
+9. bound provider at concurrency capacity falls back without crashing
+10. fallback success updates binding when rebind is enabled
+11. fallback success does not update binding when rebind is disabled
+12. strict-mode handlers use the same affinity behavior
+13. streaming requests preserve provider affinity
+14. invalid `session_affinity` config is rejected at load time
+15. header name matching behaves correctly regardless of request header casing
+16. concurrent requests for the same session behave consistently
+17. in-memory cleanup removes expired entries under load
+18. config reload preserves valid bindings and eagerly cleans stale bindings for the default in-memory store while preserving lazy cleanup as fallback
+19. after TTL expiration, the next request falls back to normal selection
+20. concurrent requests creating the same session binding behave correctly
+21. provider identity change caused by url/key/model change triggers lazy rebinding
+22. large-session-count tests validate memory and latency characteristics
+23. the same session issuing requests with sub-millisecond spacing behaves correctly
+24. preferred provider selection is unaffected by provider weight once the provider is bound
+25. session header values containing Unicode or special characters produce stable fingerprints
+26. explicit `session_id` from different authorization tokens does not collide into the same affinity bucket
+
+## Rollout Plan
+
+1. add config types and internal stable provider identity
+2. add store abstraction and default in-memory implementation
+3. add config validation helpers
+4. add session identity extraction and fingerprinting helper
+5. extend `ProviderPool` with preferred-provider selection and `get_provider_by_id()`
+6. integrate affinity into `target_message_handler`
+7. add metrics and logs
+8. add tests for passthrough, strict mode, streaming, concurrency, and reload
+9. document multi-instance requirements before enabling in production
+
+## Suggested Code Layout
+
+To keep the implementation isolated, session affinity code should live in a dedicated module:
+
+```text
+src/
+  session_affinity/
+    mod.rs
+    context.rs
+    key.rs
+    store.rs
+    metrics.rs
+```
+
+Suggested responsibilities:
+
+- `mod.rs`: public types and trait definitions
+- `context.rs`: session extraction and `SessionContext`
+- `key.rs`: session identity extraction and fingerprinting
+- `store.rs`: in-memory store implementation
+- `metrics.rs`: counters and helper recording functions
+
+`key.rs` should own:
+
+- `AffinityKey`
+- session fingerprint computation
+- provider identity computation
+
+`compute_provider_id()` should preferably be exposed as a method on `Target` or `Provider` rather than as an unrelated free function.
+
+## Optional Feature Flag
+
+A Cargo feature flag is optional if the team wants to isolate the dependency footprint:
+
+```toml
+[features]
+default = ["session-affinity"]
+session-affinity = []
+```
+
+This is not required for v1 and should only be added if dependency management or rollout strategy makes it worthwhile.
+
+## Recommended Minimal Implementation
+
+For the first iteration:
+
+- apply to all model-routed provider selection
+- prefer explicit `session_id` and fall back to `Authorization`
+- use pool-level opt-in config
+- use an in-memory TTL cache by default
+- use sliding TTL refresh
+- support rebinding on successful fallback
+- keep the feature best-effort and fail-open
+
+This gives the expected cache-affinity behavior with minimal disruption to the existing architecture.

--- a/docs/MODEL_SESSION_AFFINITY_DESIGN.md
+++ b/docs/MODEL_SESSION_AFFINITY_DESIGN.md
@@ -27,12 +27,22 @@ The design in this document is now implemented in the current codebase with the 
 
 - pool-level `session_affinity` config is supported
 - session identity is derived from configured session header and/or `Authorization: Bearer`
+- non-`Bearer` authorization schemes are ignored for affinity fallback
 - provider identity is hashed and cached on `Provider`
 - affinity applies to all model-routed requests that pass through `target_message_handler`
 - fallback can optionally rebind according to `rebind_on_fallback`
 - request-path lazy stale cleanup is implemented
 - single-process hot reload eager cleanup is implemented for the default in-memory store
 - Prometheus counters are emitted for affinity result and reload cleanup events
+
+The current test suite covers the key behavioral guarantees from this design, including:
+
+- same-session reuse across `/chat/completions`, `/responses`, `/completions`, and `/embeddings`
+- strict-mode and streaming affinity behavior
+- authorization-scoped fingerprints and special-character stability
+- fallback rebinding semantics and capacity-based fallback
+- TTL expiry, lazy stale rebinding, and eager reload cleanup
+- config validation for lowercase normalization, empty header rejection, and non-zero TTL
 
 Current implementation files:
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -19,6 +19,7 @@
 - [Strict Mode](strict-mode.md)
 - [Response Sanitization](sanitization.md)
 - [Load Balancing](load-balancing.md)
+- [Session Affinity](session-affinity.md)
 
 # Development
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -50,6 +50,13 @@ Onwards is configured through a JSON file. Each key in the `targets` object defi
 | `ttl_secs` | integer | Sliding TTL for session binding, default `300` |
 | `rebind_on_fallback` | bool | Whether successful fallback rewrites the binding, default `true` |
 
+Validation rules:
+
+- `header_name` must be non-empty after trimming
+- `header_name` is normalized to lowercase at config load time
+- `ttl_secs` must be greater than `0`
+- affinity fallback identity uses only `Authorization: Bearer <token>`
+
 ## Auth configuration
 
 The top-level `auth` object configures global authentication:

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -26,6 +26,7 @@ Onwards is configured through a JSON file. Each key in the `targets` object defi
 | `sanitize_response` | bool | No | Enforce strict OpenAI schema compliance for responses only (see [Sanitization](sanitization.md)) |
 | `strategy` | string | No | Load balancing strategy: `weighted_random` or `priority` |
 | `fallback` | object | No | Retry configuration (see [Load Balancing](load-balancing.md)) |
+| `session_affinity` | object | No | Session stickiness configuration for model-routed requests (see [Session Affinity](session-affinity.md)) |
 | `providers` | array | No | Array of provider configurations for load balancing |
 
 ## Rate limit object
@@ -40,6 +41,14 @@ Onwards is configured through a JSON file. Each key in the `targets` object defi
 | Field | Type | Description |
 |-------|------|-------------|
 | `max_concurrent_requests` | integer | Maximum number of concurrent requests |
+
+## Session affinity object
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `header_name` | string | Header used to read explicit session id, default `x-session-id` |
+| `ttl_secs` | integer | Sliding TTL for session binding, default `300` |
+| `rebind_on_fallback` | bool | Whether successful fallback rewrites the binding, default `true` |
 
 ## Auth configuration
 

--- a/docs/src/load-balancing.md
+++ b/docs/src/load-balancing.md
@@ -2,6 +2,8 @@
 
 Onwards supports load balancing across multiple providers for a single alias, with automatic failover, weighted distribution, and configurable retry behavior.
 
+If you need cache-aware stickiness on top of load balancing, see [Session Affinity](session-affinity.md).
+
 ## Configuration
 
 ```json
@@ -58,6 +60,7 @@ Settings that apply to the entire alias:
 | `response_headers` | Headers added to all responses |
 | `strategy` | `weighted_random` or `priority` |
 | `fallback` | Retry configuration (see above) |
+| `session_affinity` | Sticky session overlay for this alias |
 | `providers` | Array of provider configurations |
 
 ## Provider-level options

--- a/docs/src/session-affinity.md
+++ b/docs/src/session-affinity.md
@@ -79,6 +79,8 @@ Onwards uses two possible identity inputs:
 - explicit session header from `header_name`
 - `Authorization: Bearer <token>`
 
+Non-`Bearer` authorization schemes are ignored for affinity.
+
 Fingerprint rules:
 
 - if both exist: `SHA256(authorization + "|" + session_id)`
@@ -91,6 +93,7 @@ This means:
 - explicit `session_id` is preferred for routing stickiness
 - when `Authorization` is present, it is folded into the fingerprint to keep affinity scoped to the caller boundary
 - two tenants using the same `x-session-id` will not collide if their bearer tokens differ
+- request header casing does not matter because HTTP header lookup is case-insensitive
 
 ## Fallback Behavior
 
@@ -110,6 +113,7 @@ Binding updates on success:
 - success on the same bound provider refreshes TTL
 - success on a different provider updates the binding only if `rebind_on_fallback = true`
 - if `rebind_on_fallback = false`, the request still succeeds but the original binding is preserved
+- once a provider is already bound, that preference wins over provider weights until the binding expires or becomes stale
 
 ## Hot Reload Semantics
 
@@ -124,6 +128,9 @@ Important deployment note:
 
 - eager cleanup is appropriate for the default in-process store
 - for a shared external store across multiple gateway instances, prefer lazy cleanup only to avoid cross-instance races during staggered reloads
+
+Provider identity is derived from upstream URL, `onwards_key`, and `onwards_model`.
+Changing any of those values invalidates existing bindings for that provider.
 
 ## Metrics
 
@@ -144,6 +151,18 @@ Current `result` values:
 - `fallback_no_rebind`
 
 Raw session ids, bearer tokens, fingerprints, and provider ids are not emitted as metric labels.
+
+## Supported Request Paths
+
+Affinity is applied consistently anywhere Onwards resolves a model alias through the shared provider-selection path, including:
+
+- `/v1/chat/completions`
+- `/v1/responses`
+- `/v1/completions`
+- `/v1/embeddings`
+
+Strict mode uses the same affinity behavior because validated requests flow through the same routing path.
+Streaming requests also preserve provider affinity.
 
 ## Example Client Requests
 

--- a/docs/src/session-affinity.md
+++ b/docs/src/session-affinity.md
@@ -1,0 +1,191 @@
+# Session Affinity
+
+Onwards supports pool-level session affinity for model-routed requests. When enabled, requests for the same logical session and model alias are preferentially forwarded to the same upstream provider during a sliding TTL window.
+
+This is useful for:
+
+- prompt cache locality
+- KV cache locality
+- reducing provider hopping during multi-turn conversations
+- keeping fallback behavior explicit instead of implicit
+
+## How It Works
+
+Session affinity is an overlay on top of normal load balancing.
+
+For each request:
+
+1. Onwards resolves the requested model alias to a `ProviderPool`.
+2. If `session_affinity` is enabled for that pool, Onwards derives a session fingerprint.
+3. If a valid binding exists, Onwards tries the bound provider first.
+4. If the binding is missing, stale, unavailable, or fails under fallback rules, Onwards falls back to normal provider selection.
+5. On success, Onwards creates, refreshes, or rebinds the mapping according to configuration.
+
+Affinity applies to all requests that route through the standard model-based provider selection path, not just `/v1/chat/completions`.
+
+Important detail for first requests:
+
+- session affinity does not override the pool strategy for an unbound session
+- a session's first successful request still goes through normal provider selection
+- with `weighted_random`, two different sessions can both hit the same provider by chance
+- over many distinct first requests, distribution should still follow the underlying pool strategy rather than always picking the first provider
+
+## Configuration
+
+Add `session_affinity` at the pool level:
+
+```json
+{
+  "targets": {
+    "gpt-4o": {
+      "strategy": "weighted_random",
+      "fallback": {
+        "enabled": true,
+        "on_status": [429, 5],
+        "on_rate_limit": true
+      },
+      "session_affinity": {
+        "header_name": "x-session-id",
+        "ttl_secs": 300,
+        "rebind_on_fallback": true
+      },
+      "providers": [
+        { "url": "https://api.openai.com", "onwards_key": "sk-a", "weight": 3 },
+        { "url": "https://api.openai.com", "onwards_key": "sk-b", "weight": 1 }
+      ]
+    }
+  }
+}
+```
+
+## Fields
+
+| Field | Type | Default | Description |
+|------|------|---------|-------------|
+| `header_name` | string | `x-session-id` | Header used to read an explicit client session id |
+| `ttl_secs` | integer | `300` | Sliding TTL for the session binding |
+| `rebind_on_fallback` | bool | `true` | Whether a successful fallback provider should replace the previous binding |
+
+Validation rules:
+
+- `header_name` must be non-empty after trimming
+- `header_name` is normalized to lowercase at config load time
+- `ttl_secs` must be greater than `0`
+
+## Session Identity Rules
+
+Onwards uses two possible identity inputs:
+
+- explicit session header from `header_name`
+- `Authorization: Bearer <token>`
+
+Fingerprint rules:
+
+- if both exist: `SHA256(authorization + "|" + session_id)`
+- if only session id exists: `SHA256(session_id)`
+- if only authorization exists: `SHA256(authorization)`
+- if neither exists: affinity is skipped
+
+This means:
+
+- explicit `session_id` is preferred for routing stickiness
+- when `Authorization` is present, it is folded into the fingerprint to keep affinity scoped to the caller boundary
+- two tenants using the same `x-session-id` will not collide if their bearer tokens differ
+
+## Fallback Behavior
+
+If the bound provider:
+
+- is missing after reload
+- is at concurrency capacity
+- is locally rate limited
+- times out
+- returns a fallback-eligible status
+
+Onwards continues with normal provider selection.
+
+Binding updates on success:
+
+- first successful request for a session creates a binding
+- success on the same bound provider refreshes TTL
+- success on a different provider updates the binding only if `rebind_on_fallback = true`
+- if `rebind_on_fallback = false`, the request still succeeds but the original binding is preserved
+
+## Hot Reload Semantics
+
+Affinity state lives in `AppState`, not in `Targets`, so it survives config reload.
+
+Onwards uses two stale-cleanup modes:
+
+- lazy cleanup on request path: if a stored `provider_id` no longer exists in the current pool, the binding is deleted and the request falls back to normal selection
+- eager cleanup on successful reload: the default in-memory store removes bindings for providers that are no longer valid in the new local pool view
+
+Important deployment note:
+
+- eager cleanup is appropriate for the default in-process store
+- for a shared external store across multiple gateway instances, prefer lazy cleanup only to avoid cross-instance races during staggered reloads
+
+## Metrics
+
+Onwards exports Prometheus counters for affinity outcomes:
+
+- `session_affinity_total{model, result}`
+- `session_affinity_cleanup_total{model, reason="reload"}`
+
+Current `result` values:
+
+- `hit`
+- `miss`
+- `stale`
+- `bound`
+- `unavailable`
+- `error`
+- `rebound`
+- `fallback_no_rebind`
+
+Raw session ids, bearer tokens, fingerprints, and provider ids are not emitted as metric labels.
+
+## Example Client Requests
+
+Explicit session id plus bearer token:
+
+```bash
+curl http://localhost:3000/v1/chat/completions \
+  -H 'Authorization: Bearer tenant-a' \
+  -H 'Content-Type: application/json' \
+  -H 'X-Session-Id: conv-123' \
+  -d '{
+    "model": "gpt-4o",
+    "messages": [
+      { "role": "user", "content": "Hello" }
+    ]
+  }'
+```
+
+Bearer-only fallback:
+
+```bash
+curl http://localhost:3000/v1/chat/completions \
+  -H 'Authorization: Bearer tenant-a' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "gpt-4o",
+    "messages": [
+      { "role": "user", "content": "Hello" }
+    ]
+  }'
+```
+
+## When To Enable It
+
+Enable session affinity when:
+
+- the upstream provider benefits from prompt or KV cache reuse
+- multi-turn workloads dominate traffic
+- occasional local stickiness is a better tradeoff than pure short-term balance
+
+Avoid enabling it by default for every pool when:
+
+- requests are mostly stateless
+- traffic distribution matters more than cache locality
+- you run multiple gateway instances without an external affinity store and without outer instance stickiness

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -48,10 +48,7 @@ struct HeaderInjector<'a>(&'a mut HeaderMap);
 
 impl Injector for HeaderInjector<'_> {
     fn set(&mut self, key: &str, value: String) {
-        if let (Ok(name), Ok(val)) = (
-            key.parse::<HeaderName>(),
-            HeaderValue::from_str(&value),
-        ) {
+        if let (Ok(name), Ok(val)) = (key.parse::<HeaderName>(), HeaderValue::from_str(&value)) {
             self.0.insert(name, val);
         }
     }
@@ -72,6 +69,35 @@ fn is_preferred_provider_attempt(
             .get(idx)
             .is_some_and(|provider| provider.identity() == id)
     })
+}
+
+fn session_affinity_ttl(config: &crate::target::SessionAffinityConfig) -> std::time::Duration {
+    std::time::Duration::from_secs(config.ttl_secs)
+}
+
+fn bind_session_affinity(
+    state: &AppState<impl HttpClient>,
+    key: &AffinityKey,
+    config: &crate::target::SessionAffinityConfig,
+    provider: &crate::load_balancer::Provider,
+) {
+    state.session_affinity_store.insert(
+        key.clone(),
+        AffinityEntry {
+            provider_id: provider.identity().to_string(),
+        },
+        session_affinity_ttl(config),
+    );
+}
+
+fn touch_session_affinity(
+    state: &AppState<impl HttpClient>,
+    key: &AffinityKey,
+    config: &crate::target::SessionAffinityConfig,
+) {
+    state
+        .session_affinity_store
+        .touch(key, session_affinity_ttl(config));
 }
 
 fn handle_session_affinity_success(
@@ -96,13 +122,7 @@ fn handle_session_affinity_success(
                     "session affinity rebound"
                 );
                 record_session_affinity_result(model_name, SessionAffinityResult::Rebound);
-                state.session_affinity_store.insert(
-                    key.clone(),
-                    AffinityEntry {
-                        provider_id: provider.identity().to_string(),
-                    },
-                    std::time::Duration::from_secs(config.ttl_secs),
-                );
+                bind_session_affinity(state, key, config, provider);
             } else {
                 debug!(
                     model = %model_name,
@@ -113,21 +133,124 @@ fn handle_session_affinity_success(
                 record_session_affinity_result(model_name, SessionAffinityResult::FallbackNoRebind);
             }
         }
-        Some(_) => {
-            state
-                .session_affinity_store
-                .touch(key, std::time::Duration::from_secs(config.ttl_secs));
-        }
+        Some(_) => touch_session_affinity(state, key, config),
         None => {
             record_session_affinity_result(model_name, SessionAffinityResult::Bound);
-            state.session_affinity_store.insert(
-                key.clone(),
-                AffinityEntry {
-                    provider_id: provider.identity().to_string(),
-                },
-                std::time::Duration::from_secs(config.ttl_secs),
-            );
+            bind_session_affinity(state, key, config, provider);
         }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ResolvedSessionAffinity {
+    config: Option<crate::target::SessionAffinityConfig>,
+    key: Option<AffinityKey>,
+    preferred_provider_id: Option<String>,
+}
+
+impl ResolvedSessionAffinity {
+    fn resolve<T: HttpClient>(
+        state: &AppState<T>,
+        pool: &crate::load_balancer::ProviderPool,
+        model_name: &str,
+        headers: &HeaderMap,
+    ) -> Self {
+        let config = pool.session_affinity().cloned();
+        let key = config
+            .as_ref()
+            .and_then(|affinity| build_session_context(headers, &affinity.header_name))
+            .map(|context| AffinityKey {
+                model: model_name.to_string(),
+                session_fingerprint: context.fingerprint,
+            });
+
+        let preferred_provider_id = key.as_ref().and_then(|affinity_key| {
+            let entry = state.session_affinity_store.get(affinity_key)?;
+            if pool.get_provider_by_id(&entry.provider_id).is_some() {
+                debug!(model = %model_name, provider_id = %entry.provider_id, "session affinity hit");
+                record_session_affinity_result(model_name, SessionAffinityResult::Hit);
+                Some(entry.provider_id)
+            } else {
+                debug!(model = %model_name, provider_id = %entry.provider_id, "session affinity stale binding");
+                state.session_affinity_store.delete(affinity_key);
+                record_session_affinity_result(model_name, SessionAffinityResult::Stale);
+                None
+            }
+        });
+
+        if config.is_some() && key.is_some() && preferred_provider_id.is_none() {
+            debug!(model = %model_name, "session affinity miss");
+            record_session_affinity_result(model_name, SessionAffinityResult::Miss);
+        }
+
+        Self {
+            config,
+            key,
+            preferred_provider_id,
+        }
+    }
+
+    fn config(&self) -> Option<&crate::target::SessionAffinityConfig> {
+        self.config.as_ref()
+    }
+
+    fn key(&self) -> Option<&AffinityKey> {
+        self.key.as_ref()
+    }
+
+    fn preferred_provider_id(&self) -> Option<&str> {
+        self.preferred_provider_id.as_deref()
+    }
+}
+
+fn record_preferred_provider_error(
+    model_name: &str,
+    pool: &crate::load_balancer::ProviderPool,
+    preferred_provider_id: Option<&str>,
+    idx: usize,
+) {
+    record_preferred_provider_outcome(
+        model_name,
+        pool,
+        preferred_provider_id,
+        idx,
+        SessionAffinityResult::Error,
+        "session affinity error",
+    );
+}
+
+fn record_preferred_provider_unavailable(
+    model_name: &str,
+    pool: &crate::load_balancer::ProviderPool,
+    preferred_provider_id: Option<&str>,
+    idx: usize,
+) {
+    record_preferred_provider_outcome(
+        model_name,
+        pool,
+        preferred_provider_id,
+        idx,
+        SessionAffinityResult::Unavailable,
+        "session affinity unavailable",
+    );
+}
+
+fn record_preferred_provider_outcome(
+    model_name: &str,
+    pool: &crate::load_balancer::ProviderPool,
+    preferred_provider_id: Option<&str>,
+    idx: usize,
+    result: SessionAffinityResult,
+    message: &'static str,
+) {
+    if is_preferred_provider_attempt(preferred_provider_id, pool, idx) {
+        debug!(
+            model = %model_name,
+            provider_id = %pool.providers()[idx].identity(),
+            outcome = message,
+            "session affinity outcome"
+        );
+        record_session_affinity_result(model_name, result);
     }
 }
 
@@ -534,31 +657,8 @@ pub async fn target_message_handler<T: HttpClient>(
     // Prepare original headers and method for potential retries
     let original_headers = req.headers().clone();
     let method = req.method().clone();
-    let session_affinity = pool.session_affinity().cloned();
-    let affinity_key = session_affinity
-        .as_ref()
-        .and_then(|config| build_session_context(req.headers(), &config.header_name))
-        .map(|context| AffinityKey {
-            model: model_name.clone(),
-            session_fingerprint: context.fingerprint,
-        });
-    let preferred_provider_id = affinity_key.as_ref().and_then(|key| {
-        let entry = state.session_affinity_store.get(key)?;
-        if pool.get_provider_by_id(&entry.provider_id).is_some() {
-            debug!(model = %model_name, provider_id = %entry.provider_id, "session affinity hit");
-            record_session_affinity_result(&model_name, SessionAffinityResult::Hit);
-            Some(entry.provider_id)
-        } else {
-            debug!(model = %model_name, provider_id = %entry.provider_id, "session affinity stale binding");
-            state.session_affinity_store.delete(key);
-            record_session_affinity_result(&model_name, SessionAffinityResult::Stale);
-            None
-        }
-    });
-    if session_affinity.is_some() && affinity_key.is_some() && preferred_provider_id.is_none() {
-        debug!(model = %model_name, "session affinity miss");
-        record_session_affinity_result(&model_name, SessionAffinityResult::Miss);
-    }
+    let session_affinity =
+        ResolvedSessionAffinity::resolve(&state, &pool, &model_name, req.headers());
 
     // Track last error for fallback scenarios
     let mut last_error: Option<OnwardsErrorResponse> = None;
@@ -569,8 +669,8 @@ pub async fn target_message_handler<T: HttpClient>(
     // concurrency limit. The returned guard tracks the active connection.
     let mut any_attempted = false;
     let mut attempt_number: u32 = 0;
-    for (_idx, target, connection_guard) in
-        pool.select_iter_with_preferred(preferred_provider_id.as_deref())
+    for (idx, target, connection_guard) in
+        pool.select_iter_with_preferred(session_affinity.preferred_provider_id())
     {
         any_attempted = true;
         attempt_number += 1;
@@ -593,10 +693,12 @@ pub async fn target_message_handler<T: HttpClient>(
         {
             debug!("Provider rate limited: {:?}", target.url);
             tracing::Span::current().record("onwards.fallback", "rate_limited");
-            if is_preferred_provider_attempt(preferred_provider_id.as_deref(), &pool, _idx) {
-                debug!(model = %model_name, provider_id = %pool.providers()[_idx].identity(), "session affinity unavailable");
-                record_session_affinity_result(&model_name, SessionAffinityResult::Unavailable);
-            }
+            record_preferred_provider_unavailable(
+                &model_name,
+                &pool,
+                session_affinity.preferred_provider_id(),
+                idx,
+            );
             last_error = Some(OnwardsErrorResponse::rate_limited());
             if pool.should_fallback_on_rate_limit() {
                 debug!("Fallback on rate limit enabled, trying next provider");
@@ -739,7 +841,7 @@ pub async fn target_message_handler<T: HttpClient>(
             url.full = %upstream_uri,
             http.response.status_code = tracing::field::Empty,
         );
-        let request_result = async {
+        let request_result: Result<Response, UpstreamOutcome> = async {
             if let Some(timeout_secs) = target.request_timeout_secs {
                 let timeout_duration = std::time::Duration::from_secs(timeout_secs);
                 match tokio::time::timeout(timeout_duration, state.http_client.request(attempt_req))
@@ -751,19 +853,7 @@ pub async fn target_message_handler<T: HttpClient>(
                             "Request to {} timed out after {:?}",
                             upstream_uri, timeout_duration
                         );
-                        if is_preferred_provider_attempt(preferred_provider_id.as_deref(), &pool, idx) {
-                            debug!(model = %model_name, provider_id = %pool.providers()[idx].identity(), "session affinity error");
-                            record_session_affinity_result(&model_name, SessionAffinityResult::Error);
-                        }
-                        last_error = Some(OnwardsErrorResponse::gateway_timeout());
-
-                        // Only retry on timeout if fallback is enabled
-                        if pool.fallback_enabled() {
-                            continue;
-                        } else {
-                            record_response_status(504);
-                            return Err(last_error.unwrap());
-                        }
+                        Err(UpstreamOutcome::Timeout)
                     }
                     Ok(result) => result.map_err(UpstreamOutcome::Error),
                 }
@@ -776,10 +866,16 @@ pub async fn target_message_handler<T: HttpClient>(
         .await;
 
         // Handle request errors
-        let mut response = match request_result {
+        let mut response: Response = match request_result {
             Err(UpstreamOutcome::Timeout) => {
                 upstream_span.record("http.response.status_code", 504_u16);
                 tracing::Span::current().record("onwards.fallback", "timeout");
+                record_preferred_provider_error(
+                    &model_name,
+                    &pool,
+                    session_affinity.preferred_provider_id(),
+                    idx,
+                );
                 last_error = Some(OnwardsErrorResponse::gateway_timeout());
                 if pool.fallback_enabled() {
                     continue;
@@ -794,11 +890,12 @@ pub async fn target_message_handler<T: HttpClient>(
                     upstream_uri, e
                 );
                 tracing::Span::current().record("onwards.fallback", "network_error");
-                last_error = Some(OnwardsErrorResponse::bad_gateway());
-                if is_preferred_provider_attempt(preferred_provider_id.as_deref(), &pool, _idx) {
-                    debug!(model = %model_name, provider_id = %pool.providers()[_idx].identity(), "session affinity error");
-                    record_session_affinity_result(&model_name, SessionAffinityResult::Error);
-                }
+                record_preferred_provider_error(
+                    &model_name,
+                    &pool,
+                    session_affinity.preferred_provider_id(),
+                    idx,
+                );
                 last_error = Some(OnwardsErrorResponse::service_unavailable());
                 // Only continue to next provider if fallback is enabled
                 if pool.fallback_enabled() {
@@ -821,10 +918,12 @@ pub async fn target_message_handler<T: HttpClient>(
                 status, target.url
             );
             tracing::Span::current().record("onwards.fallback", "status_fallback");
-            if is_preferred_provider_attempt(preferred_provider_id.as_deref(), &pool, _idx) {
-                debug!(model = %model_name, provider_id = %pool.providers()[_idx].identity(), status, "session affinity error");
-                record_session_affinity_result(&model_name, SessionAffinityResult::Error);
-            }
+            record_preferred_provider_error(
+                &model_name,
+                &pool,
+                session_affinity.preferred_provider_id(),
+                idx,
+            );
             last_error = Some(OnwardsErrorResponse::bad_gateway());
             continue;
         }
@@ -1054,14 +1153,14 @@ pub async fn target_message_handler<T: HttpClient>(
             state.targets.strict_mode
         );
         if response.status().is_success()
-            && let Some(provider) = pool.providers().get(_idx)
+            && let Some(provider) = pool.providers().get(idx)
         {
             handle_session_affinity_success(
                 &state,
                 &model_name,
-                affinity_key.as_ref(),
-                session_affinity.as_ref(),
-                preferred_provider_id.as_deref(),
+                session_affinity.key(),
+                session_affinity.config(),
+                session_affinity.preferred_provider_id(),
                 provider,
             );
         }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -8,6 +8,12 @@ use crate::auth;
 use crate::client::HttpClient;
 use crate::errors::{ErrorResponseBody, OnwardsErrorResponse};
 use crate::models::ListModelResponse;
+use crate::session_affinity::{
+    AffinityEntry, AffinityKey,
+    context::build_session_context,
+    context::extract_bearer_token,
+    metrics::{SessionAffinityResult, record_result as record_session_affinity_result},
+};
 use crate::sse::SseBufferedStream;
 use crate::target::{ConcurrencyGuard, RoutingAction, Target};
 use axum::{
@@ -26,6 +32,75 @@ use tracing::{debug, error, instrument, trace};
 /// Record HTTP response status code on the current span
 fn record_response_status(status_code: u16) {
     tracing::Span::current().record("http.response.status_code", status_code);
+}
+
+fn is_preferred_provider_attempt(
+    preferred_provider_id: Option<&str>,
+    pool: &crate::load_balancer::ProviderPool,
+    idx: usize,
+) -> bool {
+    preferred_provider_id.is_some_and(|id| {
+        pool.providers()
+            .get(idx)
+            .is_some_and(|provider| provider.identity() == id)
+    })
+}
+
+fn handle_session_affinity_success(
+    state: &AppState<impl HttpClient>,
+    model_name: &str,
+    affinity_key: Option<&AffinityKey>,
+    session_affinity: Option<&crate::target::SessionAffinityConfig>,
+    preferred_provider_id: Option<&str>,
+    provider: &crate::load_balancer::Provider,
+) {
+    let (Some(key), Some(config)) = (affinity_key, session_affinity) else {
+        return;
+    };
+
+    match preferred_provider_id {
+        Some(bound_provider_id) if bound_provider_id != provider.identity() => {
+            if config.rebind_on_fallback {
+                debug!(
+                    model = %model_name,
+                    old_provider_id = bound_provider_id,
+                    new_provider_id = %provider.identity(),
+                    "session affinity rebound"
+                );
+                record_session_affinity_result(model_name, SessionAffinityResult::Rebound);
+                state.session_affinity_store.insert(
+                    key.clone(),
+                    AffinityEntry {
+                        provider_id: provider.identity().to_string(),
+                    },
+                    std::time::Duration::from_secs(config.ttl_secs),
+                );
+            } else {
+                debug!(
+                    model = %model_name,
+                    bound_provider_id = bound_provider_id,
+                    fallback_provider_id = %provider.identity(),
+                    "session affinity fallback succeeded without rebind"
+                );
+                record_session_affinity_result(model_name, SessionAffinityResult::FallbackNoRebind);
+            }
+        }
+        Some(_) => {
+            state
+                .session_affinity_store
+                .touch(key, std::time::Duration::from_secs(config.ttl_secs));
+        }
+        None => {
+            record_session_affinity_result(model_name, SessionAffinityResult::Bound);
+            state.session_affinity_store.insert(
+                key.clone(),
+                AffinityEntry {
+                    provider_id: provider.identity().to_string(),
+                },
+                std::time::Duration::from_secs(config.ttl_secs),
+            );
+        }
+    }
 }
 
 /// A stream wrapper that keeps a [`ConcurrencyGuard`] alive until the stream
@@ -227,11 +302,8 @@ pub async fn target_message_handler<T: HttpClient>(
     };
 
     // Extract bearer token for authentication and rate limiting
-    let bearer_token = req
-        .headers()
-        .get("authorization")
-        .and_then(|auth_header| auth_header.to_str().ok())
-        .and_then(|auth_value| auth_value.strip_prefix("Bearer "));
+    let bearer_token = extract_bearer_token(req.headers());
+    let bearer_token = bearer_token.as_deref();
 
     // Validate API key using pool-level keys
     if let Some(keys) = pool.keys() {
@@ -379,6 +451,31 @@ pub async fn target_message_handler<T: HttpClient>(
     // Prepare original headers and method for potential retries
     let original_headers = req.headers().clone();
     let method = req.method().clone();
+    let session_affinity = pool.session_affinity().cloned();
+    let affinity_key = session_affinity
+        .as_ref()
+        .and_then(|config| build_session_context(req.headers(), &config.header_name))
+        .map(|context| AffinityKey {
+            model: model_name.clone(),
+            session_fingerprint: context.fingerprint,
+        });
+    let preferred_provider_id = affinity_key.as_ref().and_then(|key| {
+        let entry = state.session_affinity_store.get(key)?;
+        if pool.get_provider_by_id(&entry.provider_id).is_some() {
+            debug!(model = %model_name, provider_id = %entry.provider_id, "session affinity hit");
+            record_session_affinity_result(&model_name, SessionAffinityResult::Hit);
+            Some(entry.provider_id)
+        } else {
+            debug!(model = %model_name, provider_id = %entry.provider_id, "session affinity stale binding");
+            state.session_affinity_store.delete(key);
+            record_session_affinity_result(&model_name, SessionAffinityResult::Stale);
+            None
+        }
+    });
+    if session_affinity.is_some() && affinity_key.is_some() && preferred_provider_id.is_none() {
+        debug!(model = %model_name, "session affinity miss");
+        record_session_affinity_result(&model_name, SessionAffinityResult::Miss);
+    }
 
     // Track last error for fallback scenarios
     let mut last_error: Option<OnwardsErrorResponse> = None;
@@ -388,13 +485,19 @@ pub async fn target_message_handler<T: HttpClient>(
     // lowest active_connections/weight ratio, skipping providers at their
     // concurrency limit. The returned guard tracks the active connection.
     let mut any_attempted = false;
-    for (_idx, target, connection_guard) in pool.select_iter() {
+    for (idx, target, connection_guard) in
+        pool.select_iter_with_preferred(preferred_provider_id.as_deref())
+    {
         any_attempted = true;
         // Check provider-level rate limit (skip to next if configured for rate limit fallback)
         if let Some(ref limiter) = target.limiter
             && limiter.check().is_err()
         {
             debug!("Provider rate limited: {:?}", target.url);
+            if is_preferred_provider_attempt(preferred_provider_id.as_deref(), &pool, idx) {
+                debug!(model = %model_name, provider_id = %pool.providers()[idx].identity(), "session affinity unavailable");
+                record_session_affinity_result(&model_name, SessionAffinityResult::Unavailable);
+            }
             last_error = Some(OnwardsErrorResponse::rate_limited());
             if pool.should_fallback_on_rate_limit() {
                 debug!("Fallback on rate limit enabled, trying next provider");
@@ -530,6 +633,10 @@ pub async fn target_message_handler<T: HttpClient>(
                         "Request to {} timed out after {:?}",
                         upstream_uri, timeout_duration
                     );
+                    if is_preferred_provider_attempt(preferred_provider_id.as_deref(), &pool, idx) {
+                        debug!(model = %model_name, provider_id = %pool.providers()[idx].identity(), "session affinity error");
+                        record_session_affinity_result(&model_name, SessionAffinityResult::Error);
+                    }
                     last_error = Some(OnwardsErrorResponse::gateway_timeout());
 
                     // Only retry on timeout if fallback is enabled
@@ -554,6 +661,10 @@ pub async fn target_message_handler<T: HttpClient>(
                     "Error forwarding request to target url {}: {}",
                     upstream_uri, e
                 );
+                if is_preferred_provider_attempt(preferred_provider_id.as_deref(), &pool, idx) {
+                    debug!(model = %model_name, provider_id = %pool.providers()[idx].identity(), "session affinity error");
+                    record_session_affinity_result(&model_name, SessionAffinityResult::Error);
+                }
                 last_error = Some(OnwardsErrorResponse::service_unavailable());
                 // Only continue to next provider if fallback is enabled
                 if pool.fallback_enabled() {
@@ -573,6 +684,10 @@ pub async fn target_message_handler<T: HttpClient>(
                 "Provider returned fallback status {}, trying next: {:?}",
                 status, target.url
             );
+            if is_preferred_provider_attempt(preferred_provider_id.as_deref(), &pool, idx) {
+                debug!(model = %model_name, provider_id = %pool.providers()[idx].identity(), status, "session affinity error");
+                record_session_affinity_result(&model_name, SessionAffinityResult::Error);
+            }
             last_error = Some(OnwardsErrorResponse::bad_gateway());
             continue;
         }
@@ -801,6 +916,18 @@ pub async fn target_message_handler<T: HttpClient>(
             response.headers().get(CONTENT_LENGTH),
             state.targets.strict_mode
         );
+        if response.status().is_success()
+            && let Some(provider) = pool.providers().get(idx)
+        {
+            handle_session_affinity_success(
+                &state,
+                &model_name,
+                affinity_key.as_ref(),
+                session_affinity.as_ref(),
+                preferred_provider_id.as_deref(),
+                provider,
+            );
+        }
         let resolved_trust = target.trusted.unwrap_or_else(|| pool.is_trusted());
         response
             .extensions_mut()
@@ -1626,6 +1753,9 @@ mod tests {
             http_client: mock_client,
             body_transform_fn: None,
             response_transform_fn: None,
+            session_affinity_store: std::sync::Arc::new(
+                crate::session_affinity::store::InMemorySessionAffinityStore::new(),
+            ),
             tool_executor: std::sync::Arc::new(crate::NoOpToolExecutor),
             response_store: std::sync::Arc::new(crate::NoOpResponseStore),
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ pub mod handlers;
 pub mod load_balancer;
 pub mod models;
 pub mod response_sanitizer;
+pub mod session_affinity;
 pub mod sse;
 pub mod strict;
 pub mod target;
@@ -60,6 +61,7 @@ pub mod traits;
 use client::{HttpClient, HyperClient};
 use handlers::{models as models_handler, target_message_handler};
 use models::ExtractedModel;
+use session_affinity::{SessionAffinityStore, store::InMemorySessionAffinityStore};
 pub use traits::{
     NoOpResponseStore, NoOpToolExecutor, ResponseStore, StoreError, ToolError, ToolExecutor,
 };
@@ -195,6 +197,7 @@ pub struct AppState<T: HttpClient> {
     pub targets: target::Targets,
     pub body_transform_fn: Option<BodyTransformFn>,
     pub response_transform_fn: Option<ResponseTransformFn>,
+    pub session_affinity_store: Arc<dyn SessionAffinityStore>,
     pub tool_executor: Arc<dyn ToolExecutor>,
     pub response_store: Arc<dyn ResponseStore>,
 }
@@ -212,6 +215,7 @@ impl<T: HttpClient> std::fmt::Debug for AppState<T> {
                 "response_transform_fn",
                 &self.response_transform_fn.as_ref().map(|_| "<function>"),
             )
+            .field("session_affinity_store", &"<dyn SessionAffinityStore>")
             .field("tool_executor", &"<dyn ToolExecutor>")
             .field("response_store", &"<dyn ResponseStore>")
             .finish()
@@ -233,6 +237,7 @@ impl AppState<HyperClient> {
             targets,
             body_transform_fn: None,
             response_transform_fn: None,
+            session_affinity_store: Arc::new(InMemorySessionAffinityStore::new()),
             tool_executor: Arc::new(NoOpToolExecutor),
             response_store: Arc::new(NoOpResponseStore),
         }
@@ -252,6 +257,7 @@ impl AppState<HyperClient> {
             targets,
             body_transform_fn: Some(body_transform_fn),
             response_transform_fn: None,
+            session_affinity_store: Arc::new(InMemorySessionAffinityStore::new()),
             tool_executor: Arc::new(NoOpToolExecutor),
             response_store: Arc::new(NoOpResponseStore),
         }
@@ -266,6 +272,7 @@ impl<T: HttpClient> AppState<T> {
             targets,
             body_transform_fn: None,
             response_transform_fn: None,
+            session_affinity_store: Arc::new(InMemorySessionAffinityStore::new()),
             tool_executor: Arc::new(NoOpToolExecutor),
             response_store: Arc::new(NoOpResponseStore),
         }
@@ -282,6 +289,7 @@ impl<T: HttpClient> AppState<T> {
             targets,
             body_transform_fn: Some(body_transform_fn),
             response_transform_fn: None,
+            session_affinity_store: Arc::new(InMemorySessionAffinityStore::new()),
             tool_executor: Arc::new(NoOpToolExecutor),
             response_store: Arc::new(NoOpResponseStore),
         }
@@ -290,6 +298,11 @@ impl<T: HttpClient> AppState<T> {
     /// Set the response transformation function (builder pattern)
     pub fn with_response_transform(mut self, transform_fn: ResponseTransformFn) -> Self {
         self.response_transform_fn = Some(transform_fn);
+        self
+    }
+
+    pub fn with_session_affinity_store(mut self, store: Arc<dyn SessionAffinityStore>) -> Self {
+        self.session_affinity_store = store;
         self
     }
 
@@ -959,6 +972,480 @@ mod tests {
         // Check that requests were made to the correct URLs
         assert!(requests[0].uri.contains("api.openai.com"));
         assert!(requests[1].uri.contains("api.anthropic.com"));
+    }
+
+    #[tokio::test]
+    async fn test_session_affinity_reuses_provider_for_same_session() {
+        let targets_map = Arc::new(DashMap::new());
+        let providers = vec![
+            Provider::new(
+                Target::builder()
+                    .url("https://api1.example.com".parse().unwrap())
+                    .build(),
+                1,
+            ),
+            Provider::new(
+                Target::builder()
+                    .url("https://api2.example.com".parse().unwrap())
+                    .build(),
+                1,
+            ),
+        ];
+        let pool = ProviderPool::with_config_and_affinity(
+            providers,
+            None,
+            None,
+            None,
+            None,
+            target::LoadBalanceStrategy::WeightedRandom,
+            false,
+            Vec::new(),
+            Some(target::SessionAffinityConfig {
+                header_name: "x-session-id".to_string(),
+                ttl_secs: 300,
+                rebind_on_fallback: true,
+            }),
+        );
+        targets_map.insert("gpt-4o".to_string(), pool);
+
+        let targets = Targets {
+            targets: targets_map,
+            key_rate_limiters: Arc::new(DashMap::new()),
+            key_concurrency_limiters: Arc::new(DashMap::new()),
+            key_labels: Arc::new(DashMap::new()),
+            strict_mode: false,
+            http_pool_config: None,
+        };
+
+        let mock_client = MockHttpClient::new(
+            StatusCode::OK,
+            r#"{"choices":[{"message":{"role":"assistant","content":"hi"}}]}"#,
+        );
+        let app_state = AppState::with_client(targets, mock_client.clone());
+        let router = build_router(app_state);
+        let server = TestServer::new(router).unwrap();
+
+        for _ in 0..2 {
+            let response = server
+                .post("/v1/chat/completions")
+                .add_header("x-session-id", "session-1")
+                .add_header("authorization", "Bearer tenant-a")
+                .json(&json!({
+                    "model": "gpt-4o",
+                    "messages": [{"role": "user", "content": "Hello"}]
+                }))
+                .await;
+            assert_eq!(response.status_code(), 200);
+        }
+
+        let requests = mock_client.get_requests();
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0].uri, requests[1].uri);
+    }
+
+    #[tokio::test]
+    async fn test_session_affinity_first_requests_still_distribute_across_providers() {
+        let targets_map = Arc::new(DashMap::new());
+        let providers = vec![
+            Provider::new(
+                Target::builder()
+                    .url("https://api1.example.com".parse().unwrap())
+                    .build(),
+                1,
+            ),
+            Provider::new(
+                Target::builder()
+                    .url("https://api2.example.com".parse().unwrap())
+                    .build(),
+                1,
+            ),
+        ];
+        let pool = ProviderPool::with_config_and_affinity(
+            providers,
+            None,
+            None,
+            None,
+            None,
+            target::LoadBalanceStrategy::WeightedRandom,
+            false,
+            Vec::new(),
+            Some(target::SessionAffinityConfig {
+                header_name: "x-session-id".to_string(),
+                ttl_secs: 300,
+                rebind_on_fallback: true,
+            }),
+        );
+        targets_map.insert("gpt-4o".to_string(), pool);
+
+        let targets = Targets {
+            targets: targets_map,
+            key_rate_limiters: Arc::new(DashMap::new()),
+            key_concurrency_limiters: Arc::new(DashMap::new()),
+            key_labels: Arc::new(DashMap::new()),
+            strict_mode: false,
+            http_pool_config: None,
+        };
+
+        let mock_client = MockHttpClient::new(
+            StatusCode::OK,
+            r#"{"choices":[{"message":{"role":"assistant","content":"hi"}}]}"#,
+        );
+        let app_state = AppState::with_client(targets, mock_client.clone());
+        let router = build_router(app_state);
+        let server = TestServer::new(router).unwrap();
+
+        let first_request_sessions = 400;
+        for i in 0..first_request_sessions {
+            let response = server
+                .post("/v1/chat/completions")
+                .add_header("x-session-id", format!("session-{i}"))
+                .add_header("authorization", "Bearer tenant-a")
+                .json(&json!({
+                    "model": "gpt-4o",
+                    "messages": [{"role": "user", "content": "Hello"}]
+                }))
+                .await;
+            assert_eq!(response.status_code(), 200);
+        }
+
+        let requests = mock_client.get_requests();
+        assert_eq!(requests.len(), first_request_sessions);
+
+        let api1_hits = requests
+            .iter()
+            .filter(|request| request.uri.contains("api1.example.com"))
+            .count();
+        let api2_hits = requests
+            .iter()
+            .filter(|request| request.uri.contains("api2.example.com"))
+            .count();
+
+        assert_eq!(api1_hits + api2_hits, first_request_sessions);
+        assert!(api1_hits > 0, "api1 should receive some first requests");
+        assert!(api2_hits > 0, "api2 should receive some first requests");
+
+        // First requests for distinct sessions should still use the pool's
+        // weighted selector. Two sessions can land on the same provider by
+        // chance, but over many sessions the distribution should not collapse
+        // onto a single provider.
+        assert!(
+            (120..=280).contains(&api1_hits),
+            "expected roughly balanced first-request distribution, got api1={}, api2={}",
+            api1_hits,
+            api2_hits
+        );
+    }
+
+    #[tokio::test]
+    async fn test_session_affinity_scopes_same_session_id_by_authorization() {
+        use crate::session_affinity::key::compute_session_fingerprint;
+        use crate::session_affinity::store::InMemorySessionAffinityStore;
+
+        let targets_map = Arc::new(DashMap::new());
+        let providers = vec![
+            Provider::new(
+                Target::builder()
+                    .url("https://api1.example.com".parse().unwrap())
+                    .build(),
+                1,
+            ),
+            Provider::new(
+                Target::builder()
+                    .url("https://api2.example.com".parse().unwrap())
+                    .build(),
+                1,
+            ),
+        ];
+        let pool = ProviderPool::with_config_and_affinity(
+            providers,
+            None,
+            None,
+            None,
+            None,
+            target::LoadBalanceStrategy::WeightedRandom,
+            false,
+            Vec::new(),
+            Some(target::SessionAffinityConfig {
+                header_name: "x-session-id".to_string(),
+                ttl_secs: 300,
+                rebind_on_fallback: true,
+            }),
+        );
+        targets_map.insert("gpt-4o".to_string(), pool);
+
+        let targets = Targets {
+            targets: targets_map,
+            key_rate_limiters: Arc::new(DashMap::new()),
+            key_concurrency_limiters: Arc::new(DashMap::new()),
+            key_labels: Arc::new(DashMap::new()),
+            strict_mode: false,
+            http_pool_config: None,
+        };
+
+        let mock_client = MockHttpClient::new(
+            StatusCode::OK,
+            r#"{"choices":[{"message":{"role":"assistant","content":"hi"}}]}"#,
+        );
+        let store = Arc::new(InMemorySessionAffinityStore::new());
+        let app_state = AppState::with_client(targets, mock_client.clone())
+            .with_session_affinity_store(store.clone());
+        let router = build_router(app_state);
+        let server = TestServer::new(router).unwrap();
+
+        let response = server
+            .post("/v1/chat/completions")
+            .add_header("x-session-id", "shared-session")
+            .add_header("authorization", "Bearer tenant-a")
+            .json(&json!({
+                "model": "gpt-4o",
+                "messages": [{"role": "user", "content": "Hello"}]
+            }))
+            .await;
+        assert_eq!(response.status_code(), 200);
+
+        let response = server
+            .post("/v1/chat/completions")
+            .add_header("x-session-id", "shared-session")
+            .add_header("authorization", "Bearer tenant-b")
+            .json(&json!({
+                "model": "gpt-4o",
+                "messages": [{"role": "user", "content": "Hello"}]
+            }))
+            .await;
+        assert_eq!(response.status_code(), 200);
+
+        let requests = mock_client.get_requests();
+        assert_eq!(requests.len(), 2);
+
+        let key_a = crate::session_affinity::AffinityKey {
+            model: "gpt-4o".to_string(),
+            session_fingerprint: compute_session_fingerprint(
+                Some("shared-session"),
+                Some("tenant-a"),
+            )
+            .unwrap(),
+        };
+        let key_b = crate::session_affinity::AffinityKey {
+            model: "gpt-4o".to_string(),
+            session_fingerprint: compute_session_fingerprint(
+                Some("shared-session"),
+                Some("tenant-b"),
+            )
+            .unwrap(),
+        };
+
+        assert!(store.get(&key_a).is_some());
+        assert!(store.get(&key_b).is_some());
+        assert_ne!(key_a, key_b);
+    }
+
+    #[derive(Clone, Debug)]
+    struct RoutingMockClient {
+        requests: Arc<std::sync::Mutex<Vec<String>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl HttpClient for RoutingMockClient {
+        async fn request(
+            &self,
+            req: axum::extract::Request,
+        ) -> Result<axum::response::Response, Box<dyn std::error::Error + Send + Sync>> {
+            let uri = req.uri().to_string();
+            self.requests.lock().unwrap().push(uri.clone());
+            let status = if uri.contains("api1.example.com") {
+                StatusCode::BAD_GATEWAY
+            } else {
+                StatusCode::OK
+            };
+            let body = if status.is_success() {
+                r#"{"choices":[{"message":{"role":"assistant","content":"hi"}}]}"#
+            } else {
+                r#"{"error":"upstream failed"}"#
+            };
+            Ok(axum::response::Response::builder()
+                .status(status)
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from(body))
+                .unwrap())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_session_affinity_rebinds_on_fallback_success() {
+        use crate::session_affinity::key::compute_session_fingerprint;
+        use crate::session_affinity::store::InMemorySessionAffinityStore;
+
+        let targets_map = Arc::new(DashMap::new());
+        let providers = vec![
+            Provider::new(
+                Target::builder()
+                    .url("https://api1.example.com".parse().unwrap())
+                    .build(),
+                1,
+            ),
+            Provider::new(
+                Target::builder()
+                    .url("https://api2.example.com".parse().unwrap())
+                    .build(),
+                1,
+            ),
+        ];
+        let pool = ProviderPool::with_config_and_affinity(
+            providers,
+            None,
+            None,
+            None,
+            Some(target::FallbackConfig {
+                enabled: true,
+                on_status: vec![5],
+                ..Default::default()
+            }),
+            target::LoadBalanceStrategy::Priority,
+            false,
+            Vec::new(),
+            Some(target::SessionAffinityConfig {
+                header_name: "x-session-id".to_string(),
+                ttl_secs: 300,
+                rebind_on_fallback: true,
+            }),
+        );
+        let rebound_provider_id = pool.providers()[1].identity().to_string();
+        targets_map.insert("gpt-4o".to_string(), pool);
+
+        let targets = Targets {
+            targets: targets_map,
+            key_rate_limiters: Arc::new(DashMap::new()),
+            key_concurrency_limiters: Arc::new(DashMap::new()),
+            key_labels: Arc::new(DashMap::new()),
+            strict_mode: false,
+            http_pool_config: None,
+        };
+
+        let store = Arc::new(InMemorySessionAffinityStore::new());
+        let client = RoutingMockClient {
+            requests: Arc::new(std::sync::Mutex::new(Vec::new())),
+        };
+        let app_state = AppState::with_client(targets, client.clone())
+            .with_session_affinity_store(store.clone());
+        let router = build_router(app_state);
+        let server = TestServer::new(router).unwrap();
+
+        let response = server
+            .post("/v1/chat/completions")
+            .add_header("x-session-id", "session-1")
+            .add_header("authorization", "Bearer tenant-a")
+            .json(&json!({
+                "model": "gpt-4o",
+                "messages": [{"role": "user", "content": "Hello"}]
+            }))
+            .await;
+        assert_eq!(response.status_code(), 200);
+
+        let key = crate::session_affinity::AffinityKey {
+            model: "gpt-4o".to_string(),
+            session_fingerprint: compute_session_fingerprint(Some("session-1"), Some("tenant-a"))
+                .unwrap(),
+        };
+        let entry = store.get(&key).unwrap();
+        assert_eq!(entry.provider_id, rebound_provider_id);
+
+        let requests = client.requests.lock().unwrap().clone();
+        assert_eq!(requests.len(), 2);
+        assert!(requests[0].contains("api1.example.com"));
+        assert!(requests[1].contains("api2.example.com"));
+    }
+
+    #[tokio::test]
+    async fn test_session_affinity_does_not_rebind_on_fallback_when_disabled() {
+        use crate::session_affinity::key::compute_session_fingerprint;
+        use crate::session_affinity::store::InMemorySessionAffinityStore;
+
+        let targets_map = Arc::new(DashMap::new());
+        let providers = vec![
+            Provider::new(
+                Target::builder()
+                    .url("https://api1.example.com".parse().unwrap())
+                    .build(),
+                1,
+            ),
+            Provider::new(
+                Target::builder()
+                    .url("https://api2.example.com".parse().unwrap())
+                    .build(),
+                1,
+            ),
+        ];
+        let pool = ProviderPool::with_config_and_affinity(
+            providers,
+            None,
+            None,
+            None,
+            Some(target::FallbackConfig {
+                enabled: true,
+                on_status: vec![5],
+                ..Default::default()
+            }),
+            target::LoadBalanceStrategy::Priority,
+            false,
+            Vec::new(),
+            Some(target::SessionAffinityConfig {
+                header_name: "x-session-id".to_string(),
+                ttl_secs: 300,
+                rebind_on_fallback: false,
+            }),
+        );
+        let original_provider_id = pool.providers()[0].identity().to_string();
+        targets_map.insert("gpt-4o".to_string(), pool);
+
+        let targets = Targets {
+            targets: targets_map,
+            key_rate_limiters: Arc::new(DashMap::new()),
+            key_concurrency_limiters: Arc::new(DashMap::new()),
+            key_labels: Arc::new(DashMap::new()),
+            strict_mode: false,
+            http_pool_config: None,
+        };
+
+        let store = Arc::new(InMemorySessionAffinityStore::new());
+        let key = crate::session_affinity::AffinityKey {
+            model: "gpt-4o".to_string(),
+            session_fingerprint: compute_session_fingerprint(Some("session-1"), Some("tenant-a"))
+                .unwrap(),
+        };
+        store.insert(
+            key.clone(),
+            crate::session_affinity::AffinityEntry {
+                provider_id: original_provider_id.clone(),
+            },
+            std::time::Duration::from_secs(300),
+        );
+
+        let client = RoutingMockClient {
+            requests: Arc::new(std::sync::Mutex::new(Vec::new())),
+        };
+        let app_state = AppState::with_client(targets, client.clone())
+            .with_session_affinity_store(store.clone());
+        let router = build_router(app_state);
+        let server = TestServer::new(router).unwrap();
+
+        let response = server
+            .post("/v1/chat/completions")
+            .add_header("x-session-id", "session-1")
+            .add_header("authorization", "Bearer tenant-a")
+            .json(&json!({
+                "model": "gpt-4o",
+                "messages": [{"role": "user", "content": "Hello"}]
+            }))
+            .await;
+        assert_eq!(response.status_code(), 200);
+
+        let entry = store.get(&key).unwrap();
+        assert_eq!(entry.provider_id, original_provider_id);
+
+        let requests = client.requests.lock().unwrap().clone();
+        assert_eq!(requests.len(), 2);
+        assert!(requests[0].contains("api1.example.com"));
+        assert!(requests[1].contains("api2.example.com"));
     }
 
     #[tokio::test]
@@ -1764,6 +2251,24 @@ mod tests {
         use serde_json::json;
         use std::sync::Arc;
 
+        fn counter_value(
+            metrics_text: &str,
+            metric_names: &[&str],
+            labels: &[(&str, &str)],
+        ) -> i32 {
+            metrics_text
+                .lines()
+                .find(|line| {
+                    metric_names.iter().any(|name| line.starts_with(name))
+                        && labels
+                            .iter()
+                            .all(|(key, value)| line.contains(&format!("{key}=\"{value}\"")))
+                })
+                .and_then(|line| line.split_whitespace().last())
+                .and_then(|s| s.parse::<i32>().ok())
+                .unwrap_or(0)
+        }
+
         /// Fixture to create a shared metrics server and main server.
         /// The axum-prometheus library using a global Prometheus registry that maintains state across test executions within the same process. Even
         /// with unique prefixes and serial execution, the library prevents creating multiple metric registries with overlapping metric names. So we
@@ -1773,6 +2278,29 @@ mod tests {
         fn get_shared_metrics_servers(
             #[default(Arc::new(DashMap::new()))] targets: Arc<DashMap<String, ProviderPool>>,
         ) -> (TestServer, TestServer) {
+            targets.insert(
+                "gpt-4o".to_string(),
+                ProviderPool::with_config_and_affinity(
+                    vec![Provider::new(
+                        Target::builder()
+                            .url("https://api.example.com".parse().unwrap())
+                            .build(),
+                        1,
+                    )],
+                    None,
+                    None,
+                    None,
+                    None,
+                    target::LoadBalanceStrategy::Priority,
+                    false,
+                    Vec::new(),
+                    Some(target::SessionAffinityConfig {
+                        header_name: "x-session-id".to_string(),
+                        ttl_secs: 300,
+                        rebind_on_fallback: true,
+                    }),
+                ),
+            );
             let targets = Targets {
                 targets,
                 key_rate_limiters: Arc::new(DashMap::new()),
@@ -1787,7 +2315,13 @@ mod tests {
             let metrics_router = build_metrics_router(handle);
             let metrics_server = TestServer::new(metrics_router).unwrap();
 
-            let app_state = AppState::new(targets);
+            let app_state = AppState::with_client(
+                targets,
+                MockHttpClient::new(
+                    StatusCode::OK,
+                    r#"{"choices":[{"message":{"role":"assistant","content":"hi"}}]}"#,
+                ),
+            );
             let router = build_router(app_state).layer(prometheus_layer);
             let server = TestServer::new(router).unwrap();
 
@@ -1933,6 +2467,75 @@ mod tests {
                 initial_count + 11,
                 "Metrics should increment by 11 total"
             );
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn test_metrics_server_for_session_affinity(
+            get_shared_metrics_servers: &(TestServer, TestServer),
+        ) {
+            let (server, metrics_server) = get_shared_metrics_servers;
+            let metric_names = ["onwards_session_affinity_total", "session_affinity_total"];
+
+            let initial_metrics = metrics_server.get("/metrics").await.text();
+            let initial_miss = counter_value(
+                &initial_metrics,
+                &metric_names,
+                &[("model", "gpt-4o"), ("result", "miss")],
+            );
+            let initial_bound = counter_value(
+                &initial_metrics,
+                &metric_names,
+                &[("model", "gpt-4o"), ("result", "bound")],
+            );
+            let initial_hit = counter_value(
+                &initial_metrics,
+                &metric_names,
+                &[("model", "gpt-4o"), ("result", "hit")],
+            );
+
+            let response = server
+                .post("/v1/chat/completions")
+                .add_header("x-session-id", "metrics-session")
+                .add_header("authorization", "Bearer metrics-tenant")
+                .json(&json!({
+                    "model": "gpt-4o",
+                    "messages": [{"role": "user", "content": "Hello"}]
+                }))
+                .await;
+            assert_eq!(response.status_code(), 200);
+
+            let response = server
+                .post("/v1/chat/completions")
+                .add_header("x-session-id", "metrics-session")
+                .add_header("authorization", "Bearer metrics-tenant")
+                .json(&json!({
+                    "model": "gpt-4o",
+                    "messages": [{"role": "user", "content": "Hello"}]
+                }))
+                .await;
+            assert_eq!(response.status_code(), 200);
+
+            let metrics_text = metrics_server.get("/metrics").await.text();
+            let miss = counter_value(
+                &metrics_text,
+                &metric_names,
+                &[("model", "gpt-4o"), ("result", "miss")],
+            );
+            let bound = counter_value(
+                &metrics_text,
+                &metric_names,
+                &[("model", "gpt-4o"), ("result", "bound")],
+            );
+            let hit = counter_value(
+                &metrics_text,
+                &metric_names,
+                &[("model", "gpt-4o"), ("result", "hit")],
+            );
+
+            assert_eq!(miss, initial_miss + 1);
+            assert_eq!(bound, initial_bound + 1);
+            assert_eq!(hit, initial_hit + 1);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -865,6 +865,137 @@ mod tests {
         target.into_pool()
     }
 
+    fn build_session_affinity_pool(
+        strategy: target::LoadBalanceStrategy,
+        fallback: Option<target::FallbackConfig>,
+        ttl_secs: u64,
+        rebind_on_fallback: bool,
+    ) -> ProviderPool {
+        let providers = vec![
+            Provider::new(
+                Target::builder()
+                    .url("https://api1.example.com".parse().unwrap())
+                    .build(),
+                1,
+            ),
+            Provider::new(
+                Target::builder()
+                    .url("https://api2.example.com".parse().unwrap())
+                    .build(),
+                1,
+            ),
+        ];
+
+        ProviderPool::with_config_and_affinity(
+            providers,
+            None,
+            None,
+            None,
+            fallback,
+            strategy,
+            false,
+            Vec::new(),
+            Some(target::SessionAffinityConfig {
+                header_name: "x-session-id".to_string(),
+                ttl_secs,
+                rebind_on_fallback,
+            }),
+        )
+    }
+
+    fn build_session_affinity_targets(pool: ProviderPool, strict_mode: bool) -> Targets {
+        let targets_map = Arc::new(DashMap::new());
+        targets_map.insert("gpt-4o".to_string(), pool);
+
+        Targets {
+            targets: targets_map,
+            key_rate_limiters: Arc::new(DashMap::new()),
+            key_concurrency_limiters: Arc::new(DashMap::new()),
+            key_labels: Arc::new(DashMap::new()),
+            strict_mode,
+            http_pool_config: None,
+        }
+    }
+
+    fn build_session_affinity_state<T: HttpClient>(
+        client: T,
+        pool: ProviderPool,
+        strict_mode: bool,
+    ) -> AppState<T> {
+        AppState::with_client(build_session_affinity_targets(pool, strict_mode), client)
+    }
+
+    fn build_test_server<T: HttpClient + Clone + Send + Sync + 'static>(
+        state: AppState<T>,
+        strict_mode: bool,
+    ) -> TestServer {
+        let router = if strict_mode {
+            Router::new().nest("/v1", crate::strict::build_strict_router(state))
+        } else {
+            build_router(state)
+        };
+        TestServer::new(router).unwrap()
+    }
+
+    async fn assert_json_request_ok(
+        server: &TestServer,
+        path: &str,
+        body: &serde_json::Value,
+        session_id: Option<&str>,
+        authorization: Option<&str>,
+    ) {
+        let mut request = server.post(path);
+        if let Some(session_id) = session_id {
+            request = request.add_header("x-session-id", session_id);
+        }
+        if let Some(authorization) = authorization {
+            request = request.add_header("authorization", authorization);
+        }
+
+        let response = request.json(body).await;
+        assert_eq!(response.status_code(), 200);
+    }
+
+    async fn assert_chat_completion_ok(
+        server: &TestServer,
+        session_id: Option<&str>,
+        authorization: Option<&str>,
+    ) {
+        assert_json_request_ok(
+            server,
+            "/v1/chat/completions",
+            &json!({
+                "model": "gpt-4o",
+                "messages": [{"role": "user", "content": "Hello"}]
+            }),
+            session_id,
+            authorization,
+        )
+        .await;
+    }
+
+    fn count_provider_hits(requests: &[test_utils::MockRequest]) -> (usize, usize) {
+        let api1_hits = requests
+            .iter()
+            .filter(|request| request.uri.contains("api1.example.com"))
+            .count();
+        let api2_hits = requests
+            .iter()
+            .filter(|request| request.uri.contains("api2.example.com"))
+            .count();
+        (api1_hits, api2_hits)
+    }
+
+    fn provider_host(uri: &str) -> &'static str {
+        if uri.contains("api1.example.com") {
+            "api1"
+        } else if uri.contains("api2.example.com") {
+            "api2"
+        } else {
+            panic!("unexpected provider uri: {uri}");
+        }
+    }
+
     #[tokio::test]
     async fn test_empty_targets_returns_404() {
         // Create empty targets
@@ -977,66 +1108,55 @@ mod tests {
 
     #[tokio::test]
     async fn test_session_affinity_reuses_provider_for_same_session() {
-        let targets_map = Arc::new(DashMap::new());
-        let providers = vec![
-            Provider::new(
-                Target::builder()
-                    .url("https://api1.example.com".parse().unwrap())
-                    .build(),
-                1,
-            ),
-            Provider::new(
-                Target::builder()
-                    .url("https://api2.example.com".parse().unwrap())
-                    .build(),
-                1,
-            ),
-        ];
-        let pool = ProviderPool::with_config_and_affinity(
-            providers,
-            None,
-            None,
-            None,
-            None,
-            target::LoadBalanceStrategy::WeightedRandom,
-            false,
-            Vec::new(),
-            Some(target::SessionAffinityConfig {
-                header_name: "x-session-id".to_string(),
-                ttl_secs: 300,
-                rebind_on_fallback: true,
-            }),
-        );
-        targets_map.insert("gpt-4o".to_string(), pool);
-
-        let targets = Targets {
-            targets: targets_map,
-            key_rate_limiters: Arc::new(DashMap::new()),
-            key_concurrency_limiters: Arc::new(DashMap::new()),
-            key_labels: Arc::new(DashMap::new()),
-            strict_mode: false,
-            http_pool_config: None,
-        };
-
         let mock_client = MockHttpClient::new(
             StatusCode::OK,
             r#"{"choices":[{"message":{"role":"assistant","content":"hi"}}]}"#,
         );
-        let app_state = AppState::with_client(targets, mock_client.clone());
-        let router = build_router(app_state);
-        let server = TestServer::new(router).unwrap();
+        let server = build_test_server(
+            build_session_affinity_state(
+                mock_client.clone(),
+                build_session_affinity_pool(
+                    target::LoadBalanceStrategy::WeightedRandom,
+                    None,
+                    300,
+                    true,
+                ),
+                false,
+            ),
+            false,
+        );
 
         for _ in 0..2 {
-            let response = server
-                .post("/v1/chat/completions")
-                .add_header("x-session-id", "session-1")
-                .add_header("authorization", "Bearer tenant-a")
-                .json(&json!({
-                    "model": "gpt-4o",
-                    "messages": [{"role": "user", "content": "Hello"}]
-                }))
-                .await;
-            assert_eq!(response.status_code(), 200);
+            assert_chat_completion_ok(&server, Some("session-1"), Some("Bearer tenant-a")).await;
+        }
+
+        let requests = mock_client.get_requests();
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0].uri, requests[1].uri);
+    }
+
+    #[tokio::test]
+    async fn test_session_affinity_uses_authorization_when_session_header_missing() {
+        let mock_client = MockHttpClient::new(
+            StatusCode::OK,
+            r#"{"choices":[{"message":{"role":"assistant","content":"hi"}}]}"#,
+        );
+        let server = build_test_server(
+            build_session_affinity_state(
+                mock_client.clone(),
+                build_session_affinity_pool(
+                    target::LoadBalanceStrategy::WeightedRandom,
+                    None,
+                    300,
+                    true,
+                ),
+                false,
+            ),
+            false,
+        );
+
+        for _ in 0..2 {
+            assert_chat_completion_ok(&server, None, Some("Bearer tenant-a")).await;
         }
 
         let requests = mock_client.get_requests();
@@ -1046,80 +1166,35 @@ mod tests {
 
     #[tokio::test]
     async fn test_session_affinity_first_requests_still_distribute_across_providers() {
-        let targets_map = Arc::new(DashMap::new());
-        let providers = vec![
-            Provider::new(
-                Target::builder()
-                    .url("https://api1.example.com".parse().unwrap())
-                    .build(),
-                1,
-            ),
-            Provider::new(
-                Target::builder()
-                    .url("https://api2.example.com".parse().unwrap())
-                    .build(),
-                1,
-            ),
-        ];
-        let pool = ProviderPool::with_config_and_affinity(
-            providers,
-            None,
-            None,
-            None,
-            None,
-            target::LoadBalanceStrategy::WeightedRandom,
-            false,
-            Vec::new(),
-            Some(target::SessionAffinityConfig {
-                header_name: "x-session-id".to_string(),
-                ttl_secs: 300,
-                rebind_on_fallback: true,
-            }),
-        );
-        targets_map.insert("gpt-4o".to_string(), pool);
-
-        let targets = Targets {
-            targets: targets_map,
-            key_rate_limiters: Arc::new(DashMap::new()),
-            key_concurrency_limiters: Arc::new(DashMap::new()),
-            key_labels: Arc::new(DashMap::new()),
-            strict_mode: false,
-            http_pool_config: None,
-        };
-
         let mock_client = MockHttpClient::new(
             StatusCode::OK,
             r#"{"choices":[{"message":{"role":"assistant","content":"hi"}}]}"#,
         );
-        let app_state = AppState::with_client(targets, mock_client.clone());
-        let router = build_router(app_state);
-        let server = TestServer::new(router).unwrap();
+        let server = build_test_server(
+            build_session_affinity_state(
+                mock_client.clone(),
+                build_session_affinity_pool(
+                    target::LoadBalanceStrategy::WeightedRandom,
+                    None,
+                    300,
+                    true,
+                ),
+                false,
+            ),
+            false,
+        );
 
         let first_request_sessions = 400;
         for i in 0..first_request_sessions {
-            let response = server
-                .post("/v1/chat/completions")
-                .add_header("x-session-id", format!("session-{i}"))
-                .add_header("authorization", "Bearer tenant-a")
-                .json(&json!({
-                    "model": "gpt-4o",
-                    "messages": [{"role": "user", "content": "Hello"}]
-                }))
+            let session_id = format!("session-{i}");
+            assert_chat_completion_ok(&server, Some(session_id.as_str()), Some("Bearer tenant-a"))
                 .await;
-            assert_eq!(response.status_code(), 200);
         }
 
         let requests = mock_client.get_requests();
         assert_eq!(requests.len(), first_request_sessions);
 
-        let api1_hits = requests
-            .iter()
-            .filter(|request| request.uri.contains("api1.example.com"))
-            .count();
-        let api2_hits = requests
-            .iter()
-            .filter(|request| request.uri.contains("api2.example.com"))
-            .count();
+        let (api1_hits, api2_hits) = count_provider_hits(&requests);
 
         assert_eq!(api1_hits + api2_hits, first_request_sessions);
         assert!(api1_hits > 0, "api1 should receive some first requests");
@@ -1138,82 +1213,71 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_session_affinity_without_identity_preserves_existing_distribution() {
+        let mock_client = MockHttpClient::new(
+            StatusCode::OK,
+            r#"{"choices":[{"message":{"role":"assistant","content":"hi"}}]}"#,
+        );
+        let server = build_test_server(
+            build_session_affinity_state(
+                mock_client.clone(),
+                build_session_affinity_pool(
+                    target::LoadBalanceStrategy::WeightedRandom,
+                    None,
+                    300,
+                    true,
+                ),
+                false,
+            ),
+            false,
+        );
+
+        let requests_without_identity = 400;
+        for _ in 0..requests_without_identity {
+            assert_chat_completion_ok(&server, None, None).await;
+        }
+
+        let requests = mock_client.get_requests();
+        assert_eq!(requests.len(), requests_without_identity);
+
+        let (api1_hits, api2_hits) = count_provider_hits(&requests);
+
+        assert_eq!(api1_hits + api2_hits, requests_without_identity);
+        assert!(api1_hits > 0, "api1 should receive some requests");
+        assert!(api2_hits > 0, "api2 should receive some requests");
+        assert!(
+            (120..=280).contains(&api1_hits),
+            "expected roughly balanced requests without identity, got api1={}, api2={}",
+            api1_hits,
+            api2_hits
+        );
+    }
+
+    #[tokio::test]
     async fn test_session_affinity_scopes_same_session_id_by_authorization() {
         use crate::session_affinity::key::compute_session_fingerprint;
         use crate::session_affinity::store::InMemorySessionAffinityStore;
-
-        let targets_map = Arc::new(DashMap::new());
-        let providers = vec![
-            Provider::new(
-                Target::builder()
-                    .url("https://api1.example.com".parse().unwrap())
-                    .build(),
-                1,
-            ),
-            Provider::new(
-                Target::builder()
-                    .url("https://api2.example.com".parse().unwrap())
-                    .build(),
-                1,
-            ),
-        ];
-        let pool = ProviderPool::with_config_and_affinity(
-            providers,
-            None,
-            None,
-            None,
-            None,
-            target::LoadBalanceStrategy::WeightedRandom,
-            false,
-            Vec::new(),
-            Some(target::SessionAffinityConfig {
-                header_name: "x-session-id".to_string(),
-                ttl_secs: 300,
-                rebind_on_fallback: true,
-            }),
-        );
-        targets_map.insert("gpt-4o".to_string(), pool);
-
-        let targets = Targets {
-            targets: targets_map,
-            key_rate_limiters: Arc::new(DashMap::new()),
-            key_concurrency_limiters: Arc::new(DashMap::new()),
-            key_labels: Arc::new(DashMap::new()),
-            strict_mode: false,
-            http_pool_config: None,
-        };
 
         let mock_client = MockHttpClient::new(
             StatusCode::OK,
             r#"{"choices":[{"message":{"role":"assistant","content":"hi"}}]}"#,
         );
         let store = Arc::new(InMemorySessionAffinityStore::new());
-        let app_state = AppState::with_client(targets, mock_client.clone())
-            .with_session_affinity_store(store.clone());
-        let router = build_router(app_state);
-        let server = TestServer::new(router).unwrap();
+        let app_state = build_session_affinity_state(
+            mock_client.clone(),
+            build_session_affinity_pool(
+                target::LoadBalanceStrategy::WeightedRandom,
+                None,
+                300,
+                true,
+            ),
+            false,
+        )
+        .with_session_affinity_store(store.clone());
+        let server = build_test_server(app_state, false);
 
-        let response = server
-            .post("/v1/chat/completions")
-            .add_header("x-session-id", "shared-session")
-            .add_header("authorization", "Bearer tenant-a")
-            .json(&json!({
-                "model": "gpt-4o",
-                "messages": [{"role": "user", "content": "Hello"}]
-            }))
-            .await;
-        assert_eq!(response.status_code(), 200);
-
-        let response = server
-            .post("/v1/chat/completions")
-            .add_header("x-session-id", "shared-session")
-            .add_header("authorization", "Bearer tenant-b")
-            .json(&json!({
-                "model": "gpt-4o",
-                "messages": [{"role": "user", "content": "Hello"}]
-            }))
-            .await;
-        assert_eq!(response.status_code(), 200);
+        assert_chat_completion_ok(&server, Some("shared-session"), Some("Bearer tenant-a")).await;
+        assert_chat_completion_ok(&server, Some("shared-session"), Some("Bearer tenant-b")).await;
 
         let requests = mock_client.get_requests();
         assert_eq!(requests.len(), 2);
@@ -1238,6 +1302,177 @@ mod tests {
         assert!(store.get(&key_a).is_some());
         assert!(store.get(&key_b).is_some());
         assert_ne!(key_a, key_b);
+    }
+
+    #[tokio::test]
+    async fn test_session_affinity_reuses_provider_across_model_routes() {
+        let mock_client = MockHttpClient::new(StatusCode::OK, r#"{"success": true}"#);
+        let server = build_test_server(
+            build_session_affinity_state(
+                mock_client.clone(),
+                build_session_affinity_pool(
+                    target::LoadBalanceStrategy::WeightedRandom,
+                    None,
+                    300,
+                    true,
+                ),
+                false,
+            ),
+            false,
+        );
+
+        let requests = [
+            (
+                "/v1/chat/completions",
+                json!({
+                    "model": "gpt-4o",
+                    "messages": [{"role": "user", "content": "Hello"}]
+                }),
+            ),
+            (
+                "/v1/responses",
+                json!({
+                    "model": "gpt-4o",
+                    "input": "Hello"
+                }),
+            ),
+            (
+                "/v1/completions",
+                json!({
+                    "model": "gpt-4o",
+                    "prompt": "Hello"
+                }),
+            ),
+            (
+                "/v1/embeddings",
+                json!({
+                    "model": "gpt-4o",
+                    "input": "Hello"
+                }),
+            ),
+        ];
+
+        for (path, body) in requests {
+            assert_json_request_ok(
+                &server,
+                path,
+                &body,
+                Some("shared-session"),
+                Some("Bearer tenant-a"),
+            )
+            .await;
+        }
+
+        let upstream_requests = mock_client.get_requests();
+        assert_eq!(upstream_requests.len(), 4);
+        let first_host = provider_host(&upstream_requests[0].uri);
+        assert!(
+            upstream_requests
+                .iter()
+                .all(|request| provider_host(&request.uri) == first_host)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_session_affinity_preserves_provider_for_streaming_requests() {
+        let streaming_chunks = vec![
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"},\"finish_reason\":null}]}\n\n".to_string(),
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"},\"finish_reason\":\"stop\"}]}\n\n".to_string(),
+            "data: [DONE]\n\n".to_string(),
+        ];
+        let mock_client = MockHttpClient::new_streaming(StatusCode::OK, streaming_chunks);
+        let server = build_test_server(
+            build_session_affinity_state(
+                mock_client.clone(),
+                build_session_affinity_pool(
+                    target::LoadBalanceStrategy::WeightedRandom,
+                    None,
+                    300,
+                    true,
+                ),
+                false,
+            ),
+            false,
+        );
+
+        for _ in 0..2 {
+            assert_json_request_ok(
+                &server,
+                "/v1/chat/completions",
+                &json!({
+                    "model": "gpt-4o",
+                    "stream": true,
+                    "messages": [{"role": "user", "content": "Hello"}]
+                }),
+                Some("stream-session"),
+                Some("Bearer tenant-a"),
+            )
+            .await;
+        }
+
+        let requests = mock_client.get_requests();
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0].uri, requests[1].uri);
+    }
+
+    #[tokio::test]
+    async fn test_session_affinity_lazy_rebinds_after_stale_provider_identity() {
+        use crate::session_affinity::key::{compute_provider_id, compute_session_fingerprint};
+        use crate::session_affinity::store::InMemorySessionAffinityStore;
+
+        let stale_target = Target::builder()
+            .url("https://api-stale.example.com".parse().unwrap())
+            .build();
+        let pool = ProviderPool::with_config_and_affinity(
+            vec![Provider::new(
+                Target::builder()
+                    .url("https://api-fresh.example.com".parse().unwrap())
+                    .build(),
+                1,
+            )],
+            None,
+            None,
+            None,
+            None,
+            target::LoadBalanceStrategy::WeightedRandom,
+            false,
+            Vec::new(),
+            Some(target::SessionAffinityConfig {
+                header_name: "x-session-id".to_string(),
+                ttl_secs: 300,
+                rebind_on_fallback: true,
+            }),
+        );
+        let current_provider_id = pool.providers()[0].identity().to_string();
+        let store = Arc::new(InMemorySessionAffinityStore::new());
+        let key = crate::session_affinity::AffinityKey {
+            model: "gpt-4o".to_string(),
+            session_fingerprint: compute_session_fingerprint(
+                Some("stale-session"),
+                Some("tenant-a"),
+            )
+            .unwrap(),
+        };
+        store.insert(
+            key.clone(),
+            crate::session_affinity::AffinityEntry {
+                provider_id: compute_provider_id(&stale_target),
+            },
+            std::time::Duration::from_secs(300),
+        );
+
+        let mock_client = MockHttpClient::new(StatusCode::OK, r#"{"success": true}"#);
+        let app_state = build_session_affinity_state(mock_client.clone(), pool, false)
+            .with_session_affinity_store(store.clone());
+        let server = build_test_server(app_state, false);
+
+        assert_chat_completion_ok(&server, Some("stale-session"), Some("Bearer tenant-a")).await;
+
+        let entry = store.get(&key).unwrap();
+        assert_eq!(entry.provider_id, current_provider_id);
+        let requests = mock_client.get_requests();
+        assert_eq!(requests.len(), 1);
+        assert!(requests[0].uri.contains("api-fresh.example.com"));
     }
 
     #[derive(Clone, Debug)]
@@ -1276,71 +1511,26 @@ mod tests {
         use crate::session_affinity::key::compute_session_fingerprint;
         use crate::session_affinity::store::InMemorySessionAffinityStore;
 
-        let targets_map = Arc::new(DashMap::new());
-        let providers = vec![
-            Provider::new(
-                Target::builder()
-                    .url("https://api1.example.com".parse().unwrap())
-                    .build(),
-                1,
-            ),
-            Provider::new(
-                Target::builder()
-                    .url("https://api2.example.com".parse().unwrap())
-                    .build(),
-                1,
-            ),
-        ];
-        let pool = ProviderPool::with_config_and_affinity(
-            providers,
-            None,
-            None,
-            None,
+        let pool = build_session_affinity_pool(
+            target::LoadBalanceStrategy::Priority,
             Some(target::FallbackConfig {
                 enabled: true,
                 on_status: vec![5],
                 ..Default::default()
             }),
-            target::LoadBalanceStrategy::Priority,
-            false,
-            Vec::new(),
-            Some(target::SessionAffinityConfig {
-                header_name: "x-session-id".to_string(),
-                ttl_secs: 300,
-                rebind_on_fallback: true,
-            }),
+            300,
+            true,
         );
         let rebound_provider_id = pool.providers()[1].identity().to_string();
-        targets_map.insert("gpt-4o".to_string(), pool);
-
-        let targets = Targets {
-            targets: targets_map,
-            key_rate_limiters: Arc::new(DashMap::new()),
-            key_concurrency_limiters: Arc::new(DashMap::new()),
-            key_labels: Arc::new(DashMap::new()),
-            strict_mode: false,
-            http_pool_config: None,
-        };
-
         let store = Arc::new(InMemorySessionAffinityStore::new());
         let client = RoutingMockClient {
             requests: Arc::new(std::sync::Mutex::new(Vec::new())),
         };
-        let app_state = AppState::with_client(targets, client.clone())
+        let app_state = build_session_affinity_state(client.clone(), pool, false)
             .with_session_affinity_store(store.clone());
-        let router = build_router(app_state);
-        let server = TestServer::new(router).unwrap();
+        let server = build_test_server(app_state, false);
 
-        let response = server
-            .post("/v1/chat/completions")
-            .add_header("x-session-id", "session-1")
-            .add_header("authorization", "Bearer tenant-a")
-            .json(&json!({
-                "model": "gpt-4o",
-                "messages": [{"role": "user", "content": "Hello"}]
-            }))
-            .await;
-        assert_eq!(response.status_code(), 200);
+        assert_chat_completion_ok(&server, Some("session-1"), Some("Bearer tenant-a")).await;
 
         let key = crate::session_affinity::AffinityKey {
             model: "gpt-4o".to_string(),
@@ -1357,56 +1547,91 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_session_affinity_does_not_rebind_on_fallback_when_disabled() {
+    async fn test_session_affinity_binding_overrides_provider_weights() {
         use crate::session_affinity::key::compute_session_fingerprint;
         use crate::session_affinity::store::InMemorySessionAffinityStore;
 
-        let targets_map = Arc::new(DashMap::new());
-        let providers = vec![
-            Provider::new(
-                Target::builder()
-                    .url("https://api1.example.com".parse().unwrap())
-                    .build(),
-                1,
-            ),
-            Provider::new(
-                Target::builder()
-                    .url("https://api2.example.com".parse().unwrap())
-                    .build(),
-                1,
-            ),
-        ];
         let pool = ProviderPool::with_config_and_affinity(
-            providers,
+            vec![
+                Provider::new(
+                    Target::builder()
+                        .url("https://api-light.example.com".parse().unwrap())
+                        .build(),
+                    1,
+                ),
+                Provider::new(
+                    Target::builder()
+                        .url("https://api-heavy.example.com".parse().unwrap())
+                        .build(),
+                    99,
+                ),
+            ],
             None,
             None,
             None,
-            Some(target::FallbackConfig {
-                enabled: true,
-                on_status: vec![5],
-                ..Default::default()
-            }),
-            target::LoadBalanceStrategy::Priority,
+            None,
+            target::LoadBalanceStrategy::WeightedRandom,
             false,
             Vec::new(),
             Some(target::SessionAffinityConfig {
                 header_name: "x-session-id".to_string(),
                 ttl_secs: 300,
-                rebind_on_fallback: false,
+                rebind_on_fallback: true,
             }),
         );
-        let original_provider_id = pool.providers()[0].identity().to_string();
-        targets_map.insert("gpt-4o".to_string(), pool);
-
-        let targets = Targets {
-            targets: targets_map,
-            key_rate_limiters: Arc::new(DashMap::new()),
-            key_concurrency_limiters: Arc::new(DashMap::new()),
-            key_labels: Arc::new(DashMap::new()),
-            strict_mode: false,
-            http_pool_config: None,
+        let bound_provider_id = pool.providers()[0].identity().to_string();
+        let store = Arc::new(InMemorySessionAffinityStore::new());
+        let key = crate::session_affinity::AffinityKey {
+            model: "gpt-4o".to_string(),
+            session_fingerprint: compute_session_fingerprint(
+                Some("bound-session"),
+                Some("tenant-a"),
+            )
+            .unwrap(),
         };
+        store.insert(
+            key.clone(),
+            crate::session_affinity::AffinityEntry {
+                provider_id: bound_provider_id,
+            },
+            std::time::Duration::from_secs(300),
+        );
 
+        let mock_client = MockHttpClient::new(StatusCode::OK, r#"{"success": true}"#);
+        let app_state = build_session_affinity_state(mock_client.clone(), pool, false)
+            .with_session_affinity_store(store);
+        let server = build_test_server(app_state, false);
+
+        for _ in 0..5 {
+            assert_chat_completion_ok(&server, Some("bound-session"), Some("Bearer tenant-a"))
+                .await;
+        }
+
+        let requests = mock_client.get_requests();
+        assert_eq!(requests.len(), 5);
+        assert!(
+            requests
+                .iter()
+                .all(|request| request.uri.contains("api-light.example.com"))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_session_affinity_does_not_rebind_on_fallback_when_disabled() {
+        use crate::session_affinity::key::compute_session_fingerprint;
+        use crate::session_affinity::store::InMemorySessionAffinityStore;
+
+        let pool = build_session_affinity_pool(
+            target::LoadBalanceStrategy::Priority,
+            Some(target::FallbackConfig {
+                enabled: true,
+                on_status: vec![5],
+                ..Default::default()
+            }),
+            300,
+            false,
+        );
+        let original_provider_id = pool.providers()[0].identity().to_string();
         let store = Arc::new(InMemorySessionAffinityStore::new());
         let key = crate::session_affinity::AffinityKey {
             model: "gpt-4o".to_string(),
@@ -1424,21 +1649,11 @@ mod tests {
         let client = RoutingMockClient {
             requests: Arc::new(std::sync::Mutex::new(Vec::new())),
         };
-        let app_state = AppState::with_client(targets, client.clone())
+        let app_state = build_session_affinity_state(client.clone(), pool, false)
             .with_session_affinity_store(store.clone());
-        let router = build_router(app_state);
-        let server = TestServer::new(router).unwrap();
+        let server = build_test_server(app_state, false);
 
-        let response = server
-            .post("/v1/chat/completions")
-            .add_header("x-session-id", "session-1")
-            .add_header("authorization", "Bearer tenant-a")
-            .json(&json!({
-                "model": "gpt-4o",
-                "messages": [{"role": "user", "content": "Hello"}]
-            }))
-            .await;
-        assert_eq!(response.status_code(), 200);
+        assert_chat_completion_ok(&server, Some("session-1"), Some("Bearer tenant-a")).await;
 
         let entry = store.get(&key).unwrap();
         assert_eq!(entry.provider_id, original_provider_id);
@@ -1447,6 +1662,247 @@ mod tests {
         assert_eq!(requests.len(), 2);
         assert!(requests[0].contains("api1.example.com"));
         assert!(requests[1].contains("api2.example.com"));
+    }
+
+    #[tokio::test]
+    async fn test_session_affinity_ttl_expiration_evicts_and_rebinds() {
+        use crate::session_affinity::key::compute_session_fingerprint;
+        use crate::session_affinity::store::InMemorySessionAffinityStore;
+
+        let store = Arc::new(InMemorySessionAffinityStore::new());
+        let mock_client = MockHttpClient::new(
+            StatusCode::OK,
+            r#"{"choices":[{"message":{"role":"assistant","content":"hi"}}]}"#,
+        );
+        let app_state = build_session_affinity_state(
+            mock_client.clone(),
+            build_session_affinity_pool(target::LoadBalanceStrategy::WeightedRandom, None, 1, true),
+            false,
+        )
+        .with_session_affinity_store(store.clone());
+        let server = build_test_server(app_state, false);
+
+        let affinity_key = crate::session_affinity::AffinityKey {
+            model: "gpt-4o".to_string(),
+            session_fingerprint: compute_session_fingerprint(Some("session-ttl"), Some("tenant-a"))
+                .unwrap(),
+        };
+
+        assert_chat_completion_ok(&server, Some("session-ttl"), Some("Bearer tenant-a")).await;
+        assert!(store.get(&affinity_key).is_some());
+
+        tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+        assert!(store.get(&affinity_key).is_none());
+
+        assert_chat_completion_ok(&server, Some("session-ttl"), Some("Bearer tenant-a")).await;
+        assert!(store.get(&affinity_key).is_some());
+        assert_eq!(mock_client.get_requests().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_session_affinity_concurrent_requests_leave_consistent_binding() {
+        use crate::session_affinity::key::compute_session_fingerprint;
+        use crate::session_affinity::store::InMemorySessionAffinityStore;
+        use std::rc::Rc;
+
+        let pool = build_session_affinity_pool(
+            target::LoadBalanceStrategy::WeightedRandom,
+            None,
+            300,
+            true,
+        );
+        let provider_ids = [
+            pool.providers()[0].identity().to_string(),
+            pool.providers()[1].identity().to_string(),
+        ];
+        let store = Arc::new(InMemorySessionAffinityStore::new());
+        let key = crate::session_affinity::AffinityKey {
+            model: "gpt-4o".to_string(),
+            session_fingerprint: compute_session_fingerprint(
+                Some("concurrent-session"),
+                Some("tenant-a"),
+            )
+            .unwrap(),
+        };
+
+        let mock_client =
+            test_utils::TriggeredMockHttpClient::new(StatusCode::OK, r#"{"success": true}"#);
+        let app_state = build_session_affinity_state(mock_client.clone(), pool, false)
+            .with_session_affinity_store(store.clone());
+        let server = Rc::new(build_test_server(app_state, false));
+
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async move {
+                let server_a = Rc::clone(&server);
+                let handle_a = tokio::task::spawn_local(async move {
+                    assert_chat_completion_ok(
+                        server_a.as_ref(),
+                        Some("concurrent-session"),
+                        Some("Bearer tenant-a"),
+                    )
+                    .await;
+                });
+
+                let server_b = Rc::clone(&server);
+                let handle_b = tokio::task::spawn_local(async move {
+                    assert_chat_completion_ok(
+                        server_b.as_ref(),
+                        Some("concurrent-session"),
+                        Some("Bearer tenant-a"),
+                    )
+                    .await;
+                });
+
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+                mock_client.complete_all();
+
+                handle_a.await.unwrap();
+                handle_b.await.unwrap();
+
+                let entry = store.get(&key).unwrap();
+                assert!(provider_ids.contains(&entry.provider_id));
+                assert_eq!(mock_client.get_requests().len(), 2);
+            })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn test_session_affinity_falls_back_when_bound_provider_is_at_capacity() {
+        use crate::session_affinity::key::compute_session_fingerprint;
+        use crate::session_affinity::store::InMemorySessionAffinityStore;
+        use std::rc::Rc;
+
+        let pool = ProviderPool::with_config_and_affinity(
+            vec![
+                Provider::with_concurrency_limit(
+                    Target::builder()
+                        .url("https://api1.example.com".parse().unwrap())
+                        .build(),
+                    1,
+                    1,
+                ),
+                Provider::new(
+                    Target::builder()
+                        .url("https://api2.example.com".parse().unwrap())
+                        .build(),
+                    1,
+                ),
+            ],
+            None,
+            None,
+            None,
+            Some(target::FallbackConfig {
+                enabled: true,
+                ..Default::default()
+            }),
+            target::LoadBalanceStrategy::Priority,
+            false,
+            Vec::new(),
+            Some(target::SessionAffinityConfig {
+                header_name: "x-session-id".to_string(),
+                ttl_secs: 300,
+                rebind_on_fallback: false,
+            }),
+        );
+        let bound_provider_id = pool.providers()[0].identity().to_string();
+        let store = Arc::new(InMemorySessionAffinityStore::new());
+        let key = crate::session_affinity::AffinityKey {
+            model: "gpt-4o".to_string(),
+            session_fingerprint: compute_session_fingerprint(
+                Some("busy-session"),
+                Some("tenant-a"),
+            )
+            .unwrap(),
+        };
+        store.insert(
+            key.clone(),
+            crate::session_affinity::AffinityEntry {
+                provider_id: bound_provider_id.clone(),
+            },
+            std::time::Duration::from_secs(300),
+        );
+
+        let client =
+            test_utils::TriggeredMockHttpClient::new(StatusCode::OK, r#"{"success": true}"#);
+        let app_state = build_session_affinity_state(client.clone(), pool, false)
+            .with_session_affinity_store(store.clone());
+        let server = Rc::new(build_test_server(app_state, false));
+
+        let local = tokio::task::LocalSet::new();
+        local
+            .run_until(async move {
+                let server_a = Rc::clone(&server);
+                let handle_a = tokio::task::spawn_local(async move {
+                    assert_chat_completion_ok(
+                        server_a.as_ref(),
+                        Some("busy-session"),
+                        Some("Bearer tenant-a"),
+                    )
+                    .await;
+                });
+
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+                let server_b = Rc::clone(&server);
+                let handle_b = tokio::task::spawn_local(async move {
+                    assert_chat_completion_ok(
+                        server_b.as_ref(),
+                        Some("busy-session"),
+                        Some("Bearer tenant-a"),
+                    )
+                    .await;
+                });
+
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+                client.complete_all();
+
+                handle_a.await.unwrap();
+                handle_b.await.unwrap();
+
+                let requests = client.get_requests();
+                assert_eq!(requests.len(), 2);
+                assert!(requests[0].uri.contains("api1.example.com"));
+                assert!(requests[1].uri.contains("api2.example.com"));
+
+                let entry = store.get(&key).unwrap();
+                assert_eq!(entry.provider_id, bound_provider_id);
+            })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn test_session_affinity_reuses_provider_in_strict_mode() {
+        let mock_response = r#"{
+            "id":"chatcmpl-123",
+            "object":"chat.completion",
+            "created":123,
+            "model":"gpt-4o",
+            "choices":[{"index":0,"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}]
+        }"#;
+        let mock_client = MockHttpClient::new(StatusCode::OK, mock_response);
+        let server = build_test_server(
+            build_session_affinity_state(
+                mock_client.clone(),
+                build_session_affinity_pool(
+                    target::LoadBalanceStrategy::WeightedRandom,
+                    None,
+                    300,
+                    true,
+                ),
+                true,
+            ),
+            true,
+        );
+
+        for _ in 0..2 {
+            assert_chat_completion_ok(&server, Some("strict-session"), Some("Bearer tenant-a"))
+                .await;
+        }
+
+        let requests = mock_client.get_requests();
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0].uri, requests[1].uri);
     }
 
     #[tokio::test]

--- a/src/load_balancer.rs
+++ b/src/load_balancer.rs
@@ -8,9 +8,10 @@
 //! Pool-level configuration (keys, rate limits) is shared across all providers.
 
 use crate::auth::KeySet;
+use crate::session_affinity::key::compute_provider_id;
 use crate::target::{
     ConcurrencyGuard, ConcurrencyLimiter, FallbackConfig, LoadBalanceStrategy, RateLimiter,
-    RoutingAction, RoutingRule, Target,
+    RoutingAction, RoutingRule, SessionAffinityConfig, Target,
 };
 use rand::Rng;
 use std::collections::{HashMap, HashSet};
@@ -40,6 +41,8 @@ pub struct ProviderPool {
     trusted: bool,
     /// Routing rules evaluated against key labels before processing
     routing_rules: Vec<RoutingRule>,
+    /// Optional session affinity configuration for this pool
+    session_affinity: Option<SessionAffinityConfig>,
 }
 
 /// A single provider within a pool
@@ -51,30 +54,39 @@ pub struct Provider {
     pub weight: u32,
     /// Tracks active connections and enforces optional concurrency limit
     limiter: ConcurrencyLimiter,
+    identity: String,
 }
 
 impl Provider {
     /// Create a new provider with no concurrency limit
     pub fn new(target: Target, weight: u32) -> Self {
+        let identity = compute_provider_id(&target);
         Self {
             target,
             weight,
             limiter: ConcurrencyLimiter::new(),
+            identity,
         }
     }
 
     /// Create a new provider with a concurrency limit
     pub fn with_concurrency_limit(target: Target, weight: u32, limit: usize) -> Self {
+        let identity = compute_provider_id(&target);
         Self {
             target,
             weight,
             limiter: ConcurrencyLimiter::with_limit(limit),
+            identity,
         }
     }
 
     /// Get the current number of active connections to this provider
     pub fn active_connections(&self) -> usize {
         self.limiter.active()
+    }
+
+    pub fn identity(&self) -> &str {
+        &self.identity
     }
 }
 
@@ -90,6 +102,7 @@ impl ProviderPool {
             strategy: LoadBalanceStrategy::default(),
             trusted: false,
             routing_rules: Vec::new(),
+            session_affinity: None,
         }
     }
 
@@ -104,6 +117,30 @@ impl ProviderPool {
         trusted: bool,
         routing_rules: Vec<RoutingRule>,
     ) -> Self {
+        Self::with_config_and_affinity(
+            providers,
+            keys,
+            pool_limiter,
+            pool_concurrency_limiter,
+            fallback,
+            strategy,
+            trusted,
+            routing_rules,
+            None,
+        )
+    }
+
+    pub fn with_config_and_affinity(
+        providers: Vec<Provider>,
+        keys: Option<KeySet>,
+        pool_limiter: Option<Arc<dyn RateLimiter>>,
+        pool_concurrency_limiter: Option<ConcurrencyLimiter>,
+        fallback: Option<FallbackConfig>,
+        strategy: LoadBalanceStrategy,
+        trusted: bool,
+        routing_rules: Vec<RoutingRule>,
+        session_affinity: Option<SessionAffinityConfig>,
+    ) -> Self {
         Self {
             providers,
             keys,
@@ -113,6 +150,7 @@ impl ProviderPool {
             strategy,
             trusted,
             routing_rules,
+            session_affinity,
         }
     }
 
@@ -145,6 +183,13 @@ impl ProviderPool {
     /// The number of attempts is controlled by `fallback.max_attempts`
     /// (defaults to provider count).
     pub fn select_iter(&self) -> SelectIter<'_> {
+        self.select_iter_with_preferred(None)
+    }
+
+    pub fn select_iter_with_preferred(
+        &self,
+        preferred_provider_id: Option<&str>,
+    ) -> SelectIter<'_> {
         let with_replacement = self.fallback.as_ref().is_some_and(|f| f.with_replacement);
         let max_attempts = self
             .fallback
@@ -158,7 +203,21 @@ impl ProviderPool {
             max_attempts,
             attempts: 0,
             with_replacement,
+            preferred: preferred_provider_id.and_then(|id| self.provider_index_by_id(id)),
+            preferred_tried: false,
         }
+    }
+
+    fn try_select_index(&self, idx: usize) -> Option<(usize, &Target, ConcurrencyGuard)> {
+        let provider = self.providers.get(idx)?;
+        let guard = provider.limiter.try_acquire()?;
+        Some((idx, &provider.target, guard))
+    }
+
+    fn provider_index_by_id(&self, provider_id: &str) -> Option<usize> {
+        self.providers
+            .iter()
+            .position(|provider| provider.identity() == provider_id)
     }
 
     /// Internal: select excluding specific provider indices
@@ -331,9 +390,20 @@ impl ProviderPool {
         self.trusted
     }
 
+    pub fn session_affinity(&self) -> Option<&SessionAffinityConfig> {
+        self.session_affinity.as_ref()
+    }
+
     /// Get the routing rules for this pool
     pub fn routing_rules(&self) -> &[RoutingRule] {
         &self.routing_rules
+    }
+
+    pub fn get_provider_by_id(&self, provider_id: &str) -> Option<(usize, &Provider)> {
+        self.providers
+            .iter()
+            .enumerate()
+            .find(|(_, provider)| provider.identity() == provider_id)
     }
 
     /// Evaluate routing rules against key labels.
@@ -370,14 +440,17 @@ impl ProviderPool {
                     && old_p.target.onwards_key == new_provider.target.onwards_key
                     && old_p.target.onwards_model == new_provider.target.onwards_model
             }) {
-                new_provider.limiter.adopt_active_counter(&old_provider.limiter);
+                new_provider
+                    .limiter
+                    .adopt_active_counter(&old_provider.limiter);
             }
         }
 
         // Preserve pool-level concurrency counter if both old and new have one
-        if let (Some(new_limiter), Some(old_limiter)) =
-            (&mut self.pool_concurrency_limiter, &old.pool_concurrency_limiter)
-        {
+        if let (Some(new_limiter), Some(old_limiter)) = (
+            &mut self.pool_concurrency_limiter,
+            &old.pool_concurrency_limiter,
+        ) {
             new_limiter.adopt_active_counter(old_limiter);
         }
     }
@@ -393,6 +466,8 @@ pub struct SelectIter<'a> {
     max_attempts: usize,
     attempts: usize,
     with_replacement: bool,
+    preferred: Option<usize>,
+    preferred_tried: bool,
 }
 
 impl<'a> Iterator for SelectIter<'a> {
@@ -402,6 +477,26 @@ impl<'a> Iterator for SelectIter<'a> {
         if self.attempts >= self.max_attempts {
             return None;
         }
+
+        if let Some(preferred) = self.preferred {
+            if !self.preferred_tried {
+                self.preferred_tried = true;
+                self.attempts += 1;
+                if !self.excluded.contains(&preferred) {
+                    if let Some(result) = self.pool.try_select_index(preferred) {
+                        let should_exclude = match self.pool.strategy {
+                            LoadBalanceStrategy::Priority => true,
+                            LoadBalanceStrategy::WeightedRandom => !self.with_replacement,
+                        };
+                        if should_exclude {
+                            self.excluded.insert(result.0);
+                        }
+                        return Some(result);
+                    }
+                }
+            }
+        }
+
         self.attempts += 1;
 
         let result = self.pool.select_excluding(&self.excluded)?;
@@ -1216,8 +1311,14 @@ mod tests {
 
         let old_active_0 = old_pool.providers()[0].active_connections();
         let old_active_1 = old_pool.providers()[1].active_connections();
-        assert!(old_active_0 > 0, "Should have active connections on provider 0");
-        assert!(old_active_1 > 0, "Should have active connections on provider 1");
+        assert!(
+            old_active_0 > 0,
+            "Should have active connections on provider 0"
+        );
+        assert!(
+            old_active_1 > 0,
+            "Should have active connections on provider 1"
+        );
 
         // Create a new pool (simulating a config reload) and adopt state
         let new_providers = vec![
@@ -1244,9 +1345,10 @@ mod tests {
 
     #[test]
     fn test_adopt_provider_state_new_provider_starts_at_zero() {
-        let old_providers = vec![
-            Provider::new(create_test_target("https://api1.example.com"), 1),
-        ];
+        let old_providers = vec![Provider::new(
+            create_test_target("https://api1.example.com"),
+            1,
+        )];
         let old_pool = ProviderPool::new(old_providers);
 
         // Accumulate connections on old pool
@@ -1281,9 +1383,10 @@ mod tests {
             .collect();
 
         // New pool removes api2
-        let new_providers = vec![
-            Provider::new(create_test_target("https://api1.example.com"), 1),
-        ];
+        let new_providers = vec![Provider::new(
+            create_test_target("https://api1.example.com"),
+            1,
+        )];
         let mut new_pool = ProviderPool::new(new_providers);
         new_pool.adopt_provider_state(&old_pool);
 
@@ -1297,7 +1400,10 @@ mod tests {
         use crate::target::ConcurrencyLimiter;
 
         let old_pool = ProviderPool::with_config(
-            vec![Provider::new(create_test_target("https://api1.example.com"), 1)],
+            vec![Provider::new(
+                create_test_target("https://api1.example.com"),
+                1,
+            )],
             None,
             None,
             Some(ConcurrencyLimiter::with_limit(100)),
@@ -1313,7 +1419,10 @@ mod tests {
         assert_eq!(old_pool.pool_concurrency_limiter().unwrap().active(), 2);
 
         let mut new_pool = ProviderPool::with_config(
-            vec![Provider::new(create_test_target("https://api1.example.com"), 1)],
+            vec![Provider::new(
+                create_test_target("https://api1.example.com"),
+                1,
+            )],
             None,
             None,
             Some(ConcurrencyLimiter::with_limit(200)), // new limit
@@ -1328,6 +1437,65 @@ mod tests {
         // Should have adopted the active count
         assert_eq!(new_pool.pool_concurrency_limiter().unwrap().active(), 2);
         // But the new limit should apply
-        assert_eq!(new_pool.pool_concurrency_limiter().unwrap().limit(), Some(200));
+        assert_eq!(
+            new_pool.pool_concurrency_limiter().unwrap().limit(),
+            Some(200)
+        );
+    }
+
+    #[test]
+    fn test_select_iter_with_preferred_provider_uses_binding_first() {
+        let providers = vec![
+            Provider::new(create_test_target("https://api1.example.com"), 1),
+            Provider::new(create_test_target("https://api2.example.com"), 1),
+        ];
+
+        let preferred_id = providers[1].identity().to_string();
+        let pool = ProviderPool::with_config(
+            providers,
+            None,
+            None,
+            None,
+            None,
+            LoadBalanceStrategy::WeightedRandom,
+            false,
+            Vec::new(),
+        );
+
+        let (idx, target, _guard) = pool
+            .select_iter_with_preferred(Some(&preferred_id))
+            .next()
+            .unwrap();
+        assert_eq!(idx, 1);
+        assert_eq!(target.url.as_str(), "https://api2.example.com/");
+    }
+
+    #[test]
+    fn test_select_iter_with_preferred_provider_falls_back_when_full() {
+        let providers = vec![
+            Provider::with_concurrency_limit(create_test_target("https://api1.example.com"), 1, 1),
+            Provider::new(create_test_target("https://api2.example.com"), 1),
+        ];
+
+        let preferred_id = providers[0].identity().to_string();
+        let pool = ProviderPool::with_config(
+            providers,
+            None,
+            None,
+            None,
+            None,
+            LoadBalanceStrategy::Priority,
+            false,
+            Vec::new(),
+        );
+
+        let (_idx, _target, preferred_guard) = pool.select().unwrap();
+        let (fallback_idx, fallback_target, _guard) = pool
+            .select_iter_with_preferred(Some(&preferred_id))
+            .next()
+            .unwrap();
+        assert_eq!(fallback_idx, 1);
+        assert_eq!(fallback_target.url.as_str(), "https://api2.example.com/");
+        drop(preferred_guard);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,10 +30,17 @@ pub async fn main() -> anyhow::Result<()> {
     // Check if strict mode is enabled
     let strict_mode = targets.strict_mode;
 
+    // Register the sanitizer globally - per-target sanitize_response flag controls when it's applied
+    let app_state = AppState::new(targets).with_response_transform(create_openai_sanitizer());
+
     // Start file watcher if a config file was specified
     if config.watch {
-        targets
-            .receive_updates(WatchedFile(config.targets.clone()))
+        app_state
+            .targets
+            .receive_updates_with_session_affinity(
+                WatchedFile(config.targets.clone()),
+                Some(app_state.session_affinity_store.clone()),
+            )
             .await?;
     }
 
@@ -53,9 +60,6 @@ pub async fn main() -> anyhow::Result<()> {
         info!("Metrics endpoint disabled");
         None
     };
-
-    // Register the sanitizer globally - per-target sanitize_response flag controls when it's applied
-    let app_state = AppState::new(targets).with_response_transform(create_openai_sanitizer());
 
     // Use strict router if strict_mode is enabled, otherwise use standard router
     let mut router = if strict_mode {

--- a/src/session_affinity/context.rs
+++ b/src/session_affinity/context.rs
@@ -1,0 +1,75 @@
+use axum::http::HeaderMap;
+
+use crate::session_affinity::key::compute_session_fingerprint;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionSource {
+    HeaderOnly,
+    AuthorizationOnly,
+    HeaderAndAuthorization,
+    None,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionContext {
+    pub fingerprint: String,
+    pub source: SessionSource,
+}
+
+pub fn extract_bearer_token(headers: &HeaderMap) -> Option<String> {
+    let raw = headers.get("authorization")?.to_str().ok()?.trim();
+    let (scheme, token) = raw.split_once(' ')?;
+    if !scheme.eq_ignore_ascii_case("bearer") {
+        return None;
+    }
+    let token = token.trim();
+    (!token.is_empty()).then(|| token.to_string())
+}
+
+pub fn extract_session_header(headers: &HeaderMap, header_name: &str) -> Option<String> {
+    let value = headers.get(header_name)?.to_str().ok()?.trim();
+    (!value.is_empty()).then(|| value.to_string())
+}
+
+pub fn build_session_context(
+    headers: &HeaderMap,
+    session_header_name: &str,
+) -> Option<SessionContext> {
+    let session_id = extract_session_header(headers, session_header_name);
+    let authorization = extract_bearer_token(headers);
+    let fingerprint = compute_session_fingerprint(session_id.as_deref(), authorization.as_deref())?;
+
+    let source = match (session_id.is_some(), authorization.is_some()) {
+        (true, true) => SessionSource::HeaderAndAuthorization,
+        (true, false) => SessionSource::HeaderOnly,
+        (false, true) => SessionSource::AuthorizationOnly,
+        (false, false) => SessionSource::None,
+    };
+
+    Some(SessionContext {
+        fingerprint,
+        source,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::{HeaderMap, HeaderValue};
+
+    #[test]
+    fn header_whitespace_is_ignored() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-session-id", HeaderValue::from_static("  abc  "));
+        let session = extract_session_header(&headers, "x-session-id").unwrap();
+        assert_eq!(session, "abc");
+    }
+
+    #[test]
+    fn bearer_scheme_is_case_insensitive() {
+        let mut headers = HeaderMap::new();
+        headers.insert("authorization", HeaderValue::from_static("bEaReR token"));
+        let token = extract_bearer_token(&headers).unwrap();
+        assert_eq!(token, "token");
+    }
+}

--- a/src/session_affinity/context.rs
+++ b/src/session_affinity/context.rs
@@ -10,6 +10,17 @@ pub enum SessionSource {
     None,
 }
 
+impl SessionSource {
+    fn from_identity_inputs(has_session_id: bool, has_authorization: bool) -> Self {
+        match (has_session_id, has_authorization) {
+            (true, true) => Self::HeaderAndAuthorization,
+            (true, false) => Self::HeaderOnly,
+            (false, true) => Self::AuthorizationOnly,
+            (false, false) => Self::None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SessionContext {
     pub fingerprint: String,
@@ -39,16 +50,9 @@ pub fn build_session_context(
     let authorization = extract_bearer_token(headers);
     let fingerprint = compute_session_fingerprint(session_id.as_deref(), authorization.as_deref())?;
 
-    let source = match (session_id.is_some(), authorization.is_some()) {
-        (true, true) => SessionSource::HeaderAndAuthorization,
-        (true, false) => SessionSource::HeaderOnly,
-        (false, true) => SessionSource::AuthorizationOnly,
-        (false, false) => SessionSource::None,
-    };
-
     Some(SessionContext {
         fingerprint,
-        source,
+        source: SessionSource::from_identity_inputs(session_id.is_some(), authorization.is_some()),
     })
 }
 
@@ -71,5 +75,60 @@ mod tests {
         headers.insert("authorization", HeaderValue::from_static("bEaReR token"));
         let token = extract_bearer_token(&headers).unwrap();
         assert_eq!(token, "token");
+    }
+
+    #[test]
+    fn header_lookup_is_case_insensitive() {
+        let mut headers = HeaderMap::new();
+        headers.insert("X-Session-Id", HeaderValue::from_static("session-1"));
+        let session = extract_session_header(&headers, "x-session-id").unwrap();
+        assert_eq!(session, "session-1");
+    }
+
+    #[test]
+    fn non_bearer_authorization_is_ignored() {
+        let mut headers = HeaderMap::new();
+        headers.insert("authorization", HeaderValue::from_static("Basic tenant-a"));
+        assert!(extract_bearer_token(&headers).is_none());
+        assert!(build_session_context(&headers, "x-session-id").is_none());
+    }
+
+    #[test]
+    fn build_session_context_marks_header_only_source() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-session-id", HeaderValue::from_static("session-1"));
+
+        let session = build_session_context(&headers, "x-session-id").unwrap();
+
+        assert_eq!(session.source, SessionSource::HeaderOnly);
+    }
+
+    #[test]
+    fn build_session_context_marks_authorization_only_source() {
+        let mut headers = HeaderMap::new();
+        headers.insert("authorization", HeaderValue::from_static("Bearer tenant-a"));
+
+        let session = build_session_context(&headers, "x-session-id").unwrap();
+
+        assert_eq!(session.source, SessionSource::AuthorizationOnly);
+    }
+
+    #[test]
+    fn build_session_context_marks_combined_source() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-session-id", HeaderValue::from_static("session-1"));
+        headers.insert("authorization", HeaderValue::from_static("Bearer tenant-a"));
+
+        let session = build_session_context(&headers, "x-session-id").unwrap();
+
+        assert_eq!(session.source, SessionSource::HeaderAndAuthorization);
+    }
+
+    #[test]
+    fn session_source_marks_missing_identity() {
+        assert_eq!(
+            SessionSource::from_identity_inputs(false, false),
+            SessionSource::None
+        );
     }
 }

--- a/src/session_affinity/key.rs
+++ b/src/session_affinity/key.rs
@@ -1,0 +1,57 @@
+use crate::target::Target;
+use sha2::{Digest, Sha256};
+
+pub fn compute_session_fingerprint(
+    session_id: Option<&str>,
+    authorization: Option<&str>,
+) -> Option<String> {
+    let identity = match (session_id, authorization) {
+        (Some(session_id), Some(authorization)) => format!("{authorization}|{session_id}"),
+        (Some(session_id), None) => session_id.to_string(),
+        (None, Some(authorization)) => authorization.to_string(),
+        (None, None) => return None,
+    };
+
+    let mut hasher = Sha256::new();
+    hasher.update(identity.as_bytes());
+    Some(hex::encode(hasher.finalize()))
+}
+
+pub fn compute_provider_id(target: &Target) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(target.url.as_str().as_bytes());
+    hasher.update(b"|");
+    hasher.update(target.onwards_key.as_deref().unwrap_or("").as_bytes());
+    hasher.update(b"|");
+    hasher.update(target.onwards_model.as_deref().unwrap_or("").as_bytes());
+    let digest = hex::encode(hasher.finalize());
+    digest[..16].to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::target::Target;
+
+    #[test]
+    fn fingerprint_combines_auth_boundary() {
+        let a = compute_session_fingerprint(Some("session"), Some("auth-a")).unwrap();
+        let b = compute_session_fingerprint(Some("session"), Some("auth-b")).unwrap();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn provider_id_uses_delimiters() {
+        let left = Target::builder()
+            .url("https://api.example.com/".parse().unwrap())
+            .onwards_key("12".to_string())
+            .onwards_model("3".to_string())
+            .build();
+        let right = Target::builder()
+            .url("https://api.example.com1/".parse().unwrap())
+            .onwards_key("2".to_string())
+            .onwards_model("3".to_string())
+            .build();
+        assert_ne!(compute_provider_id(&left), compute_provider_id(&right));
+    }
+}

--- a/src/session_affinity/key.rs
+++ b/src/session_affinity/key.rs
@@ -54,4 +54,44 @@ mod tests {
             .build();
         assert_ne!(compute_provider_id(&left), compute_provider_id(&right));
     }
+
+    #[test]
+    fn fingerprint_is_stable_for_special_character_identity() {
+        let first =
+            compute_session_fingerprint(Some("session:one/alpha"), Some("tenant+a@example"))
+                .unwrap();
+        let second =
+            compute_session_fingerprint(Some("session:one/alpha"), Some("tenant+a@example"))
+                .unwrap();
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn provider_id_changes_when_identity_inputs_change() {
+        let base = Target::builder()
+            .url("https://api.example.com/".parse().unwrap())
+            .onwards_key("key-a".to_string())
+            .onwards_model("model-a".to_string())
+            .build();
+        let different_url = Target::builder()
+            .url("https://api-alt.example.com/".parse().unwrap())
+            .onwards_key("key-a".to_string())
+            .onwards_model("model-a".to_string())
+            .build();
+        let different_key = Target::builder()
+            .url("https://api.example.com/".parse().unwrap())
+            .onwards_key("key-b".to_string())
+            .onwards_model("model-a".to_string())
+            .build();
+        let different_model = Target::builder()
+            .url("https://api.example.com/".parse().unwrap())
+            .onwards_key("key-a".to_string())
+            .onwards_model("model-b".to_string())
+            .build();
+
+        let base_id = compute_provider_id(&base);
+        assert_ne!(base_id, compute_provider_id(&different_url));
+        assert_ne!(base_id, compute_provider_id(&different_key));
+        assert_ne!(base_id, compute_provider_id(&different_model));
+    }
 }

--- a/src/session_affinity/metrics.rs
+++ b/src/session_affinity/metrics.rs
@@ -1,0 +1,50 @@
+use metrics::counter;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionAffinityResult {
+    Hit,
+    Miss,
+    Stale,
+    Bound,
+    Unavailable,
+    Error,
+    Rebound,
+    FallbackNoRebind,
+}
+
+impl SessionAffinityResult {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Hit => "hit",
+            Self::Miss => "miss",
+            Self::Stale => "stale",
+            Self::Bound => "bound",
+            Self::Unavailable => "unavailable",
+            Self::Error => "error",
+            Self::Rebound => "rebound",
+            Self::FallbackNoRebind => "fallback_no_rebind",
+        }
+    }
+}
+
+pub fn record_result(model: &str, result: SessionAffinityResult) {
+    counter!(
+        "session_affinity_total",
+        "model" => model.to_string(),
+        "result" => result.as_str()
+    )
+    .increment(1);
+}
+
+pub fn record_cleanup(model: &str, reason: &'static str, removed: usize) {
+    if removed == 0 {
+        return;
+    }
+
+    counter!(
+        "session_affinity_cleanup_total",
+        "model" => model.to_string(),
+        "reason" => reason
+    )
+    .increment(removed as u64);
+}

--- a/src/session_affinity/mod.rs
+++ b/src/session_affinity/mod.rs
@@ -1,0 +1,33 @@
+pub mod context;
+pub mod key;
+pub mod metrics;
+pub mod store;
+
+use std::collections::HashSet;
+use std::time::Duration;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AffinityKey {
+    pub model: String,
+    pub session_fingerprint: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AffinityEntry {
+    pub provider_id: String,
+}
+
+pub trait SessionAffinityStore: Send + Sync + std::fmt::Debug {
+    fn get(&self, key: &AffinityKey) -> Option<AffinityEntry>;
+    fn insert(&self, key: AffinityKey, entry: AffinityEntry, ttl: Duration);
+    fn delete(&self, key: &AffinityKey);
+    fn touch(&self, key: &AffinityKey, ttl: Duration);
+
+    /// Remove bindings for `model` whose provider is no longer valid in the
+    /// current process. In-memory stores can eagerly clean up on hot reload;
+    /// distributed stores may choose to keep the default no-op and rely on
+    /// request-path lazy cleanup to avoid cross-instance races.
+    fn remove_stale_for_model(&self, _model: &str, _valid_provider_ids: &HashSet<String>) -> usize {
+        0
+    }
+}

--- a/src/session_affinity/store.rs
+++ b/src/session_affinity/store.rs
@@ -1,0 +1,157 @@
+use crate::session_affinity::{AffinityEntry, AffinityKey, SessionAffinityStore};
+use dashmap::DashMap;
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone)]
+pub struct InMemorySessionAffinityStore {
+    entries: Arc<DashMap<AffinityKey, StoredEntry>>,
+}
+
+#[derive(Debug, Clone)]
+struct StoredEntry {
+    provider_id: String,
+    expires_at: Instant,
+    ttl: Duration,
+}
+
+impl InMemorySessionAffinityStore {
+    pub fn new() -> Self {
+        Self {
+            entries: Arc::new(DashMap::new()),
+        }
+    }
+}
+
+impl Default for InMemorySessionAffinityStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SessionAffinityStore for InMemorySessionAffinityStore {
+    fn get(&self, key: &AffinityKey) -> Option<AffinityEntry> {
+        let entry = self.entries.get(key)?;
+        if Instant::now() >= entry.expires_at {
+            drop(entry);
+            self.entries.remove(key);
+            return None;
+        }
+
+        Some(AffinityEntry {
+            provider_id: entry.provider_id.clone(),
+        })
+    }
+
+    fn insert(&self, key: AffinityKey, entry: AffinityEntry, ttl: Duration) {
+        self.entries.insert(
+            key,
+            StoredEntry {
+                provider_id: entry.provider_id,
+                expires_at: Instant::now() + ttl,
+                ttl,
+            },
+        );
+    }
+
+    fn delete(&self, key: &AffinityKey) {
+        self.entries.remove(key);
+    }
+
+    fn touch(&self, key: &AffinityKey, ttl: Duration) {
+        if let Some(mut entry) = self.entries.get_mut(key) {
+            let effective_ttl = if ttl.is_zero() { entry.ttl } else { ttl };
+            entry.ttl = effective_ttl;
+            entry.expires_at = Instant::now() + effective_ttl;
+        }
+    }
+
+    fn remove_stale_for_model(&self, model: &str, valid_provider_ids: &HashSet<String>) -> usize {
+        let keys_to_remove: Vec<_> = self
+            .entries
+            .iter()
+            .filter(|entry| {
+                entry.key().model == model && !valid_provider_ids.contains(&entry.provider_id)
+            })
+            .map(|entry| entry.key().clone())
+            .collect();
+
+        let removed = keys_to_remove.len();
+        for key in keys_to_remove {
+            self.entries.remove(&key);
+        }
+
+        removed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expired_entries_are_evicted() {
+        let store = InMemorySessionAffinityStore::new();
+        let key = AffinityKey {
+            model: "gpt-4o".into(),
+            session_fingerprint: "abc".into(),
+        };
+        store.insert(
+            key.clone(),
+            AffinityEntry {
+                provider_id: "p1".into(),
+            },
+            Duration::from_millis(1),
+        );
+        std::thread::sleep(Duration::from_millis(5));
+        assert!(store.get(&key).is_none());
+    }
+
+    #[test]
+    fn remove_stale_for_model_prunes_invalid_bindings_only() {
+        let store = InMemorySessionAffinityStore::new();
+        let keep_key = AffinityKey {
+            model: "gpt-4o".into(),
+            session_fingerprint: "keep".into(),
+        };
+        let remove_key = AffinityKey {
+            model: "gpt-4o".into(),
+            session_fingerprint: "remove".into(),
+        };
+        let other_model_key = AffinityKey {
+            model: "claude-3".into(),
+            session_fingerprint: "other".into(),
+        };
+
+        store.insert(
+            keep_key.clone(),
+            AffinityEntry {
+                provider_id: "p-valid".into(),
+            },
+            Duration::from_secs(60),
+        );
+        store.insert(
+            remove_key.clone(),
+            AffinityEntry {
+                provider_id: "p-stale".into(),
+            },
+            Duration::from_secs(60),
+        );
+        store.insert(
+            other_model_key.clone(),
+            AffinityEntry {
+                provider_id: "p-stale".into(),
+            },
+            Duration::from_secs(60),
+        );
+
+        let valid_provider_ids = HashSet::from([String::from("p-valid")]);
+        let removed = store.remove_stale_for_model("gpt-4o", &valid_provider_ids);
+
+        assert_eq!(removed, 1);
+        assert!(store.get(&keep_key).is_some());
+        assert!(store.get(&remove_key).is_none());
+        assert!(store.get(&other_model_key).is_some());
+    }
+}

--- a/src/strict/handlers.rs
+++ b/src/strict/handlers.rs
@@ -4480,7 +4480,10 @@ mod tests {
     #[tokio::test]
     async fn test_completions_rejects_missing_model() {
         let mock_client = MockHttpClient::new(StatusCode::OK, "{}");
-        let state = AppState::with_client(completions_test_targets("gpt-3.5-turbo-instruct"), mock_client);
+        let state = AppState::with_client(
+            completions_test_targets("gpt-3.5-turbo-instruct"),
+            mock_client,
+        );
         let router = crate::strict::build_strict_router(state);
 
         let request = Request::builder()
@@ -4548,20 +4551,27 @@ mod tests {
         }"#;
 
         let mock_client = MockHttpClient::new(StatusCode::OK, mock_response);
-        let state = AppState::with_client(completions_test_targets("gpt-3.5-turbo-instruct"), mock_client);
+        let state = AppState::with_client(
+            completions_test_targets("gpt-3.5-turbo-instruct"),
+            mock_client,
+        );
         let router = crate::strict::build_strict_router(state);
 
         let request = Request::builder()
             .method("POST")
             .uri("/completions")
             .header("content-type", "application/json")
-            .body(Body::from(r#"{"model":"gpt-3.5-turbo-instruct","prompt":"Say hello"}"#))
+            .body(Body::from(
+                r#"{"model":"gpt-3.5-turbo-instruct","prompt":"Say hello"}"#,
+            ))
             .unwrap();
 
         let response = router.oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
 
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let body_str = String::from_utf8(body.to_vec()).unwrap();
 
         // Standard fields present
@@ -4608,11 +4618,15 @@ mod tests {
             .method("POST")
             .uri("/completions")
             .header("content-type", "application/json")
-            .body(Body::from(r#"{"model":"gpt-3.5-turbo-instruct","prompt":"Hello"}"#))
+            .body(Body::from(
+                r#"{"model":"gpt-3.5-turbo-instruct","prompt":"Hello"}"#,
+            ))
             .unwrap();
 
         let response = router.oneshot(request).await.unwrap();
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let body_str = String::from_utf8(body.to_vec()).unwrap();
 
         // Client-requested model reflected back, not the internal provider model
@@ -4638,14 +4652,19 @@ mod tests {
         let mut mock_client = MockHttpClient::new(StatusCode::OK, mock_response);
         mock_client.set_header("content-length", mock_response.len().to_string());
 
-        let state = AppState::with_client(completions_test_targets("gpt-3.5-turbo-instruct"), mock_client);
+        let state = AppState::with_client(
+            completions_test_targets("gpt-3.5-turbo-instruct"),
+            mock_client,
+        );
         let router = crate::strict::build_strict_router(state);
 
         let request = Request::builder()
             .method("POST")
             .uri("/completions")
             .header("content-type", "application/json")
-            .body(Body::from(r#"{"model":"gpt-3.5-turbo-instruct","prompt":"Hi"}"#))
+            .body(Body::from(
+                r#"{"model":"gpt-3.5-turbo-instruct","prompt":"Hi"}"#,
+            ))
             .unwrap();
 
         let response = router.oneshot(request).await.unwrap();
@@ -4659,12 +4678,17 @@ mod tests {
             .and_then(|v| v.parse().ok())
             .expect("content-length header should be present");
 
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let body_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
         // Content-Length must match the sanitized body (stripped of extra fields)
         assert_eq!(content_length, body.len());
-        assert!(content_length < mock_response.len(), "sanitized body should be smaller");
+        assert!(
+            content_length < mock_response.len(),
+            "sanitized body should be smaller"
+        );
 
         // Sanitized body has model rewritten and extra fields removed
         assert_eq!(body_json["model"], "gpt-3.5-turbo-instruct");
@@ -4699,8 +4723,7 @@ mod tests {
 
         // The prompt array is forwarded to the upstream (it can handle it)
         let requests = mock_client.get_requests();
-        let request_json: serde_json::Value =
-            serde_json::from_slice(&requests[0].body).unwrap();
+        let request_json: serde_json::Value = serde_json::from_slice(&requests[0].body).unwrap();
         assert!(request_json["prompt"].is_array());
     }
 
@@ -4714,7 +4737,10 @@ mod tests {
                 "data: [DONE]\n\n".to_string(),
             ],
         );
-        let state = AppState::with_client(completions_test_targets("gpt-3.5-turbo-instruct"), mock_client);
+        let state = AppState::with_client(
+            completions_test_targets("gpt-3.5-turbo-instruct"),
+            mock_client,
+        );
         let router = crate::strict::build_strict_router(state);
 
         let request = Request::builder()
@@ -4729,7 +4755,9 @@ mod tests {
         let response = router.oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
 
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let body_str = String::from_utf8(body.to_vec()).unwrap();
 
         // Standard completions chunk fields present
@@ -4786,7 +4814,9 @@ mod tests {
             .unwrap();
 
         let response = router.oneshot(request).await.unwrap();
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let body_str = String::from_utf8(body.to_vec()).unwrap();
 
         // Client-requested model reflected back, not the internal provider version
@@ -4799,20 +4829,27 @@ mod tests {
     async fn test_completions_untrusted_error_sanitized() {
         let mock_error = r#"{"error":{"message":"Provider internal error: OOM on GPU 3","code":"oom","provider":"custom-llm"}}"#;
         let mock_client = MockHttpClient::new(StatusCode::INTERNAL_SERVER_ERROR, mock_error);
-        let state = AppState::with_client(completions_test_targets("gpt-3.5-turbo-instruct"), mock_client);
+        let state = AppState::with_client(
+            completions_test_targets("gpt-3.5-turbo-instruct"),
+            mock_client,
+        );
         let router = crate::strict::build_strict_router(state);
 
         let request = Request::builder()
             .method("POST")
             .uri("/completions")
             .header("content-type", "application/json")
-            .body(Body::from(r#"{"model":"gpt-3.5-turbo-instruct","prompt":"Hello"}"#))
+            .body(Body::from(
+                r#"{"model":"gpt-3.5-turbo-instruct","prompt":"Hello"}"#,
+            ))
             .unwrap();
 
         let response = router.oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
 
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let body_str = String::from_utf8(body.to_vec()).unwrap();
 
         // Provider-specific error details not leaked
@@ -4865,13 +4902,17 @@ mod tests {
             .method("POST")
             .uri("/completions")
             .header("content-type", "application/json")
-            .body(Body::from(r#"{"model":"gpt-3.5-turbo-instruct","prompt":"Hello"}"#))
+            .body(Body::from(
+                r#"{"model":"gpt-3.5-turbo-instruct","prompt":"Hello"}"#,
+            ))
             .unwrap();
 
         let response = router.oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let body_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
         // Trusted provider: original error passed through verbatim
@@ -4930,13 +4971,17 @@ mod tests {
             .method("POST")
             .uri("/completions")
             .header("content-type", "application/json")
-            .body(Body::from(r#"{"model":"gpt-3.5-turbo-instruct","prompt":"Hi"}"#))
+            .body(Body::from(
+                r#"{"model":"gpt-3.5-turbo-instruct","prompt":"Hi"}"#,
+            ))
             .unwrap();
 
         let response = router.oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
 
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let body_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
         // Model rewritten even for trusted provider

--- a/src/strict/mod.rs
+++ b/src/strict/mod.rs
@@ -575,7 +575,10 @@ mod tests {
             "usage": {"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12}
         }"#;
         let mock_client = MockHttpClient::new(StatusCode::OK, mock_response);
-        (AppState::with_client(targets, mock_client.clone()), mock_client)
+        (
+            AppState::with_client(targets, mock_client.clone()),
+            mock_client,
+        )
     }
 
     /// The strict router accepts POST /completions with a valid request body

--- a/src/target.rs
+++ b/src/target.rs
@@ -2706,6 +2706,29 @@ mod tests {
     }
 
     #[test]
+    fn test_session_affinity_rejects_empty_header_name() {
+        let json = r#"{
+            "targets": {
+                "gpt-4o": {
+                    "session_affinity": {
+                        "header_name": "   ",
+                        "ttl_secs": 300
+                    },
+                    "providers": [
+                        {
+                            "url": "https://api.example.com"
+                        }
+                    ]
+                }
+            }
+        }"#;
+
+        let config: ConfigFile = serde_json::from_str(json).unwrap();
+        let err = Targets::from_config(config).unwrap_err();
+        assert!(err.to_string().contains("session_affinity.header_name"));
+    }
+
+    #[test]
     fn test_provider_spec_trusted_defaults_to_none() {
         let json = r#"{"url": "https://example.com"}"#;
         let spec: ProviderSpec = serde_json::from_str(json).unwrap();

--- a/src/target.rs
+++ b/src/target.rs
@@ -15,6 +15,9 @@
 //! Provider-level configuration (url, onwards_key, weight) is specific to each provider.
 use crate::auth::KeySet;
 use crate::load_balancer::{Provider, ProviderPool};
+use crate::session_affinity::{
+    SessionAffinityStore, metrics::record_cleanup as record_affinity_cleanup,
+};
 use anyhow::anyhow;
 use async_trait::async_trait;
 use bon::Builder;
@@ -22,6 +25,7 @@ use dashmap::DashMap;
 use futures_util::{Stream, StreamExt};
 use governor::{DefaultDirectRateLimiter, Quota};
 use notify::{Config as NotifyConfig, RecommendedWatcher, RecursiveMode, Watcher};
+use serde::Deserializer;
 use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::{collections::HashMap, num::NonZeroU32, path::PathBuf, pin::Pin, sync::Arc};
@@ -29,6 +33,67 @@ use tokio::sync::mpsc;
 use tokio_stream::wrappers::{ReceiverStream, WatchStream};
 use tracing::{debug, error, info, trace};
 use url::Url;
+
+fn deserialize_lowercase<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = String::deserialize(deserializer)?;
+    Ok(value.trim().to_ascii_lowercase())
+}
+
+fn default_session_affinity_header_name() -> String {
+    "x-session-id".to_string()
+}
+
+fn default_session_affinity_ttl_secs() -> u64 {
+    300
+}
+
+fn default_session_affinity_rebind_on_fallback() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Builder)]
+pub struct SessionAffinityConfig {
+    #[serde(
+        default = "default_session_affinity_header_name",
+        deserialize_with = "deserialize_lowercase"
+    )]
+    #[builder(default = default_session_affinity_header_name())]
+    pub header_name: String,
+    #[serde(default = "default_session_affinity_ttl_secs")]
+    #[builder(default = default_session_affinity_ttl_secs())]
+    pub ttl_secs: u64,
+    #[serde(default = "default_session_affinity_rebind_on_fallback")]
+    #[builder(default = default_session_affinity_rebind_on_fallback())]
+    pub rebind_on_fallback: bool,
+}
+
+impl SessionAffinityConfig {
+    pub fn validate(&self) -> Result<(), anyhow::Error> {
+        if self.header_name.trim().is_empty() {
+            return Err(anyhow!("session_affinity.header_name must not be empty"));
+        }
+        if self.ttl_secs == 0 {
+            return Err(anyhow!(
+                "session_affinity.ttl_secs must be greater than zero"
+            ));
+        }
+        if self.ttl_secs > 3600 {
+            tracing::warn!(
+                ttl_secs = self.ttl_secs,
+                "session_affinity.ttl_secs > 3600 may increase memory pressure"
+            );
+        }
+        if !self.rebind_on_fallback {
+            tracing::info!(
+                "session_affinity.rebind_on_fallback=false may keep sessions sticky to degraded providers"
+            );
+        }
+        Ok(())
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RateLimitParameters {
@@ -213,6 +278,9 @@ pub struct PoolSpec {
     #[serde(default)]
     pub routing_rules: Vec<RoutingRule>,
 
+    #[serde(default)]
+    pub session_affinity: Option<SessionAffinityConfig>,
+
     /// The list of providers to load balance across
     pub providers: Vec<ProviderSpec>,
 }
@@ -296,6 +364,7 @@ pub struct PoolConfig {
     pub open_responses: Option<OpenResponsesConfig>,
     pub trusted: bool,
     pub routing_rules: Vec<RoutingRule>,
+    pub session_affinity: Option<SessionAffinityConfig>,
     pub providers: Vec<ProviderSpec>,
 }
 
@@ -314,6 +383,7 @@ impl TargetSpecOrList {
                 open_responses: pool.open_responses,
                 trusted: pool.trusted,
                 routing_rules: pool.routing_rules,
+                session_affinity: pool.session_affinity,
                 providers: pool.providers,
             }),
             TargetSpecOrList::List(list) => {
@@ -359,6 +429,7 @@ impl TargetSpecOrList {
                     open_responses: None,
                     trusted,
                     routing_rules: Vec::new(),
+                    session_affinity: None,
                     providers,
                 })
             }
@@ -394,6 +465,7 @@ impl TargetSpecOrList {
                     open_responses,
                     trusted,
                     routing_rules: Vec::new(),
+                    session_affinity: None,
                     providers: vec![provider],
                 })
             }
@@ -821,6 +893,38 @@ impl TargetsStream for WatchTargetsStream {
     }
 }
 
+fn cleanup_session_affinity_bindings(
+    targets: &Arc<DashMap<String, ProviderPool>>,
+    models: &std::collections::HashSet<String>,
+    store: &Arc<dyn SessionAffinityStore>,
+) {
+    for model in models {
+        let valid_provider_ids = targets
+            .get(model)
+            .map(|pool| {
+                if pool.session_affinity().is_some() {
+                    pool.providers()
+                        .iter()
+                        .map(|provider| provider.identity().to_string())
+                        .collect()
+                } else {
+                    std::collections::HashSet::new()
+                }
+            })
+            .unwrap_or_default();
+        let removed = store.remove_stale_for_model(model, &valid_provider_ids);
+
+        if removed > 0 {
+            info!(
+                model = %model,
+                removed,
+                "removed stale session affinity bindings after config reload"
+            );
+            record_affinity_cleanup(model, "reload", removed);
+        }
+    }
+}
+
 impl Targets {
     pub async fn from_config_file(config_path: &PathBuf) -> Result<Self, anyhow::Error> {
         let contents = tokio::fs::read_to_string(config_path).await.map_err(|e| {
@@ -914,6 +1018,10 @@ impl Targets {
                 .concurrency_limit
                 .map(|cl| ConcurrencyLimiter::with_limit(cl.max_concurrent_requests));
 
+            if let Some(ref config) = pool_config.session_affinity {
+                config.validate()?;
+            }
+
             // Convert provider specs to providers
             // Pool-level sanitize_response enables sanitization for all providers
             let pool_sanitize = pool_config.sanitize_response;
@@ -936,7 +1044,7 @@ impl Targets {
                 })
                 .collect();
 
-            let pool = ProviderPool::with_config(
+            let pool = ProviderPool::with_config_and_affinity(
                 providers,
                 merged_keys,
                 pool_limiter,
@@ -945,6 +1053,7 @@ impl Targets {
                 pool_config.strategy,
                 pool_config.trusted,
                 pool_config.routing_rules,
+                pool_config.session_affinity,
             );
             debug!(
                 "Created provider pool '{}' with {} provider(s), fallback enabled: {}, strategy: {:?}",
@@ -976,10 +1085,26 @@ impl Targets {
         W: TargetsStream + Send + 'static,
         W::Error: Into<anyhow::Error>,
     {
+        self.receive_updates_with_session_affinity(targets_stream, None)
+            .await
+    }
+
+    /// Receives updates and optionally performs eager stale session-affinity cleanup.
+    /// Request-path lazy cleanup remains in place as the correctness fallback.
+    pub async fn receive_updates_with_session_affinity<W>(
+        &self,
+        targets_stream: W,
+        session_affinity_store: Option<Arc<dyn SessionAffinityStore>>,
+    ) -> Result<(), W::Error>
+    where
+        W: TargetsStream + Send + 'static,
+        W::Error: Into<anyhow::Error>,
+    {
         let targets = Arc::clone(&self.targets);
         let key_rate_limiters = Arc::clone(&self.key_rate_limiters);
         let key_concurrency_limiters = Arc::clone(&self.key_concurrency_limiters);
         let key_labels = Arc::clone(&self.key_labels);
+        let session_affinity_store = session_affinity_store.clone();
 
         let mut stream = targets_stream.stream().await?;
 
@@ -994,6 +1119,8 @@ impl Targets {
                         // Update targets atomically
                         let current_target_keys: Vec<String> =
                             targets.iter().map(|entry| entry.key().clone()).collect();
+                        let cleanup_models: std::collections::HashSet<String> =
+                            current_target_keys.iter().cloned().collect();
 
                         // Do it like this for atomicity (if you delete and recreate, there's a
                         // moment with no targets during which requests can fail)
@@ -1074,6 +1201,10 @@ impl Targets {
                         for entry in new_targets.key_labels.iter() {
                             key_labels.insert(entry.key().clone(), entry.value().clone());
                         }
+
+                        if let Some(store) = session_affinity_store.as_ref() {
+                            cleanup_session_affinity_bindings(&targets, &cleanup_models, store);
+                        }
                     }
                     Err(e) => {
                         let err: anyhow::Error = e.into();
@@ -1091,6 +1222,8 @@ impl Targets {
 mod tests {
     use super::*;
     use crate::auth::ConstantTimeString;
+    use crate::session_affinity::store::InMemorySessionAffinityStore;
+    use crate::session_affinity::{AffinityEntry, AffinityKey};
     use dashmap::DashMap;
     use std::collections::HashSet;
     use std::sync::Arc;
@@ -1304,6 +1437,150 @@ mod tests {
         assert_eq!(target.url.as_str(), "https://api.openai.com/v2");
         assert_eq!(target.onwards_key, Some("new-key".to_string()));
         assert_eq!(target.onwards_model, Some("gpt-4-turbo".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_config_watcher_cleans_stale_session_affinity_bindings() {
+        let initial_targets = Targets {
+            targets: Arc::new(DashMap::new()),
+            key_rate_limiters: Arc::new(DashMap::new()),
+            key_concurrency_limiters: Arc::new(DashMap::new()),
+            key_labels: Arc::new(DashMap::new()),
+            strict_mode: false,
+            http_pool_config: None,
+        };
+
+        let initial_pool = ProviderPool::with_config_and_affinity(
+            vec![Provider::new(
+                Target::builder()
+                    .url("https://api1.example.com".parse().unwrap())
+                    .build(),
+                1,
+            )],
+            None,
+            None,
+            None,
+            None,
+            LoadBalanceStrategy::Priority,
+            false,
+            Vec::new(),
+            Some(SessionAffinityConfig {
+                header_name: "x-session-id".into(),
+                ttl_secs: 300,
+                rebind_on_fallback: true,
+            }),
+        );
+        let valid_provider_id = initial_pool.providers()[0].identity().to_string();
+        initial_targets
+            .targets
+            .insert("gpt-4o".to_string(), initial_pool);
+        initial_targets.targets.insert(
+            "claude-3".to_string(),
+            ProviderPool::with_config_and_affinity(
+                vec![Provider::new(
+                    Target::builder()
+                        .url("https://anthropic.example.com".parse().unwrap())
+                        .build(),
+                    1,
+                )],
+                None,
+                None,
+                None,
+                None,
+                LoadBalanceStrategy::Priority,
+                false,
+                Vec::new(),
+                Some(SessionAffinityConfig {
+                    header_name: "x-session-id".into(),
+                    ttl_secs: 300,
+                    rebind_on_fallback: true,
+                }),
+            ),
+        );
+
+        let updated_pool = ProviderPool::with_config_and_affinity(
+            vec![Provider::new(
+                Target::builder()
+                    .url("https://api2.example.com".parse().unwrap())
+                    .build(),
+                1,
+            )],
+            None,
+            None,
+            None,
+            None,
+            LoadBalanceStrategy::Priority,
+            false,
+            Vec::new(),
+            Some(SessionAffinityConfig {
+                header_name: "x-session-id".into(),
+                ttl_secs: 300,
+                rebind_on_fallback: true,
+            }),
+        );
+        let updated_provider_id = updated_pool.providers()[0].identity().to_string();
+
+        let updated_targets = Targets {
+            targets: Arc::new(DashMap::new()),
+            key_rate_limiters: Arc::new(DashMap::new()),
+            key_concurrency_limiters: Arc::new(DashMap::new()),
+            key_labels: Arc::new(DashMap::new()),
+            strict_mode: false,
+            http_pool_config: None,
+        };
+        updated_targets
+            .targets
+            .insert("gpt-4o".to_string(), updated_pool);
+
+        let store = Arc::new(InMemorySessionAffinityStore::new());
+        let stale_key = AffinityKey {
+            model: "gpt-4o".into(),
+            session_fingerprint: "stale".into(),
+        };
+        let removed_model_key = AffinityKey {
+            model: "claude-3".into(),
+            session_fingerprint: "deleted-model".into(),
+        };
+        let valid_key = AffinityKey {
+            model: "gpt-4o".into(),
+            session_fingerprint: "valid".into(),
+        };
+        store.insert(
+            stale_key.clone(),
+            AffinityEntry {
+                provider_id: valid_provider_id,
+            },
+            tokio::time::Duration::from_secs(300),
+        );
+        store.insert(
+            removed_model_key.clone(),
+            AffinityEntry {
+                provider_id: "provider-removed".into(),
+            },
+            tokio::time::Duration::from_secs(300),
+        );
+        store.insert(
+            valid_key.clone(),
+            AffinityEntry {
+                provider_id: updated_provider_id.clone(),
+            },
+            tokio::time::Duration::from_secs(300),
+        );
+
+        let mock_watcher = MockConfigWatcher::with_targets(vec![updated_targets]);
+        initial_targets
+            .receive_updates_with_session_affinity(mock_watcher, Some(store.clone()))
+            .await
+            .unwrap();
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+        assert!(store.get(&stale_key).is_none());
+        assert!(store.get(&removed_model_key).is_none());
+        assert_eq!(
+            store.get(&valid_key).unwrap().provider_id,
+            updated_provider_id
+        );
     }
 
     #[test]
@@ -2130,6 +2407,7 @@ mod tests {
             open_responses: None,
             trusted: true,
             routing_rules: Vec::new(),
+            session_affinity: None,
             providers: vec![ProviderSpec {
                 url: "https://api.example.com".parse().unwrap(),
                 onwards_key: None,
@@ -2377,6 +2655,54 @@ mod tests {
             !pool.is_trusted(),
             "Pool without trusted flag should default to false"
         );
+    }
+
+    #[test]
+    fn test_session_affinity_header_name_is_normalized_to_lowercase() {
+        let json = r#"{
+            "targets": {
+                "gpt-4o": {
+                    "session_affinity": {
+                        "header_name": "X-Session-ID",
+                        "ttl_secs": 300
+                    },
+                    "providers": [
+                        {
+                            "url": "https://api.example.com"
+                        }
+                    ]
+                }
+            }
+        }"#;
+
+        let config: ConfigFile = serde_json::from_str(json).unwrap();
+        let targets = Targets::from_config(config).unwrap();
+        let pool = targets.targets.get("gpt-4o").unwrap();
+        let affinity = pool.session_affinity().unwrap();
+        assert_eq!(affinity.header_name, "x-session-id");
+    }
+
+    #[test]
+    fn test_session_affinity_rejects_zero_ttl() {
+        let json = r#"{
+            "targets": {
+                "gpt-4o": {
+                    "session_affinity": {
+                        "header_name": "x-session-id",
+                        "ttl_secs": 0
+                    },
+                    "providers": [
+                        {
+                            "url": "https://api.example.com"
+                        }
+                    ]
+                }
+            }
+        }"#;
+
+        let config: ConfigFile = serde_json::from_str(json).unwrap();
+        let err = Targets::from_config(config).unwrap_err();
+        assert!(err.to_string().contains("session_affinity.ttl_secs"));
     }
 
     #[test]


### PR DESCRIPTION
# Model Session Affinity Design

## Summary

This document proposes a v1 session affinity design for model-based provider selection in Onwards.

The goal is to keep requests for the same logical session on the same upstream provider for the same requested model alias during a configurable TTL window.

Session input resolution in v1 uses this precedence:

1. read explicit client-provided `session_id` if present
2. read `Authorization` if present
3. derive the final session fingerprint from the composition rules below

The primary use case is upstream cache affinity for chat-style workloads:

- prompt cache locality
- KV cache locality
- warm conversational context on the same backend
- avoiding unnecessary cache misses caused by provider hopping

The design preserves existing authentication, routing rules, rate limiting, concurrency limits, strict-mode validation, and fallback behavior.

## Implementation Status

The design in this document is now implemented in the current codebase with the following scope:

- pool-level `session_affinity` config is supported
- session identity is derived from configured session header and/or `Authorization: Bearer`
- provider identity is hashed and cached on `Provider`
- affinity applies to all model-routed requests that pass through `target_message_handler`
- fallback can optionally rebind according to `rebind_on_fallback`
- request-path lazy stale cleanup is implemented
- single-process hot reload eager cleanup is implemented for the default in-memory store
- Prometheus counters are emitted for affinity result and reload cleanup events

Current implementation files:

- `src/session_affinity/mod.rs`
- `src/session_affinity/context.rs`
- `src/session_affinity/key.rs`
- `src/session_affinity/store.rs`
- `src/session_affinity/metrics.rs`
- `src/handlers.rs`
- `src/load_balancer.rs`
- `src/target.rs`
- `src/main.rs`

## Current State

Today, provider selection is purely pool-based:

1. Extract `model` from header or request body.
2. Resolve the model alias to a `ProviderPool`.
3. Apply auth, routing rules, rate limits, and concurrency limits.
4. Select a provider using `ProviderPool::select_iter()`.
5. Retry on fallback conditions if configured.

Relevant code:

- `src/handlers.rs`: `target_message_handler`
- `src/load_balancer.rs`: `ProviderPool`, `select()`, `select_iter()`
- `src/strict/handlers.rs`: validated requests are forwarded into the same handler path
- `src/target.rs`: config loading and hot reload

There is currently no persistent binding from `(model alias, session identity)` to a provider.

## Problem Statement

Some clients can provide a stable `session_id`, but many OpenAI-compatible clients do not.

In practice, the proxy already has another stable signal: `Authorization: Bearer <token>`.

If the same logical session repeatedly hits the same model alias within a short time window, forwarding those requests to the same upstream provider can materially improve cache hit rates and reduce latency variance.

## Goals

- Support session affinity for any request that selects a provider via model alias.
- Enable affinity per model alias, not globally.
- Prefer explicit `session_id` as the session discriminator when provided by the client.
- Fold `Authorization` into the fingerprint whenever it is available so affinity stays scoped to the caller boundary.
- Preserve current behavior when affinity is not configured and when neither `session_id` nor `Authorization` is available.
- Work in both passthrough mode and strict mode.
- Interoperate correctly with fallback and provider hot reload.
- Keep the design compatible with single-instance and multi-instance deployments.

## Non-Goals

- Affinity for requests that do not resolve a model alias.
- Inferring identity from request payload content.
- Cross-model affinity. Bindings are scoped to one requested model alias.
- Durable conversation state management. This is routing affinity, not transcript storage.
- Perfect per-end-user affinity when multiple real users share one API key and no explicit `session_id` is provided.

## Design Position

### Affinity overlay, not a new strategy

Although the user-visible behavior may look like a load balancing strategy, affinity should not replace `weighted_random` or `priority`.

Affinity is better modeled as an overlay on top of existing selection:

1. If a valid binding exists, prefer the bound provider.
2. Otherwise, use the existing pool strategy to choose a provider.

This keeps the current load balancing semantics intact for first selection and fallback selection.

Concretely, provider selection becomes two-phase:

1. normal selection path: existing `strategy` and `fallback`
2. session-aware selection path: reuse an existing binding if one exists, otherwise delegate to the normal path

This separation keeps the feature easy to reason about and aligns with proven designs used in other projects.

### Pool-level opt-in

Affinity should be configured on the `PoolSpec` for a model alias. This keeps the feature local to aliases that benefit from cache affinity.

### Session identity with fallback

The proxy should prefer an explicit client-provided session identifier when available.

When the client does not provide one, the proxy should fall back to bearer-token-derived identity.

This matches current integration reality:

- supports clients that already have first-class session semantics
- requires no client-side protocol change when they do not
- aligns with the current auth flow
- gives stable affinity per session and per model alias

### Affinity must stay within auth boundaries

Session affinity should not allow one caller to steer itself into another caller's affinity bucket simply by guessing a `session_id`.

Recommended v1 rule:

- if `session_id` exists and `Authorization` exists, fingerprint both together
- if only `session_id` exists, fingerprint `session_id` alone
- if only `Authorization` exists, fingerprint `Authorization` alone

This keeps explicit session affinity scoped within the caller's auth boundary when auth is available, which is important for multi-tenant deployments.

### Affinity is best-effort

If the bound provider is unavailable, removed by config reload, at concurrency capacity, or rejected by local fallback policy, the request should still proceed through normal provider selection.

### Rebinding happens after successful takeover

The binding should only move to a new provider after that provider successfully handles the request.

## Proposed Configuration

Add pool-level configuration in `src/target.rs`:

```rust
#[derive(Debug, Clone, Serialize, Deserialize, Default)]
pub struct SessionAffinityConfig {
    #[serde(default = "default_session_affinity_header_name")]
    pub header_name: String,

    #[serde(default = "default_session_affinity_ttl_secs")]
    pub ttl_secs: u64,

    #[serde(default = "default_session_affinity_rebind_on_fallback")]
    pub rebind_on_fallback: bool,
}
```

Add to `PoolSpec`:

```rust
#[serde(default)]
pub session_affinity: Option<SessionAffinityConfig>,
```

Suggested defaults:

- `header_name = "x-session-id"`
- `ttl_secs = 300`
- `rebind_on_fallback = true`

Enablement rule:

- `session_affinity` absent: disabled
- `session_affinity` present: enabled

First-version scope:

- the explicit session id is read from a configured header
- `Authorization` is used as a fallback identity source and as a caller boundary when present
- no per-pool capacity tuning is configurable yet
- no separate affinity strategy enum is introduced

Example:

```json
{
  "targets": {
    "gpt-4o": {
      "strategy": "weighted_random",
      "fallback": {
        "enabled": true,
        "on_status": [429, 5],
        "on_rate_limit": true
      },
      "session_affinity": {
        "header_name": "x-session-id",
        "ttl_secs": 300,
        "rebind_on_fallback": true
      },
      "providers": [
        { "url": "https://api.openai.com", "onwards_key": "sk-a", "weight": 3 },
        { "url": "https://api.openai.com", "onwards_key": "sk-b", "weight": 1 }
      ]
    }
  }
}
```

## Configuration Validation

`session_affinity` should be validated at config load time.

Required validation rules:

- `header_name` must be non-empty after trimming
- `ttl_secs` must be greater than zero
- the pool must still contain at least one selectable provider

Normalization rules:

- trim `header_name`
- normalize `header_name` to lowercase at config load time
- use the normalized value at request time

Recommended implementation:

```rust
#[serde(deserialize_with = "deserialize_lowercase")]
pub header_name: String,
```

This keeps runtime request handling simple and avoids repeated case normalization.

Advisory validation:

- if `ttl_secs > 3600`, emit a warning because long TTLs may increase memory pressure and reduce rebalance responsiveness
- if `rebind_on_fallback = false`, emit an informational log because sessions may remain sticky to a degraded original provider

Failing fast at config load time is preferable to silently disabling affinity at runtime.

## Provider Identity

Affinity mappings must not depend on provider index in the pool because provider order can change on config reload.

For v1, provider identity should remain an internal implementation detail.

At load time, derive a deterministic provider identity from:

- `url`
- `onwards_key`
- `onwards_model`

The runtime affinity mapping should store `provider_id`, not provider index.

The identity should be computed by hashing structured inputs rather than concatenating raw strings.

Recommended v1 approach:

```rust
fn compute_provider_id(target: &Target) -> String {
    let mut hasher = Sha256::new();
    hasher.update(target.url.as_str().as_bytes());
    hasher.update(b"|");
    hasher.update(target.onwards_key.as_deref().unwrap_or("").as_bytes());
    hasher.update(b"|");
    hasher.update(target.onwards_model.as_deref().unwrap_or("").as_bytes());
    hex::encode(hasher.finalize())[..16].to_string()
}
```

Notes:

- do not expose raw `onwards_key` in logs, metrics, or debug output
- hashing avoids leaking secrets through identity construction
- a short stable digest is sufficient as an internal provider identifier
- the computed identity should be cached on `Provider` at construction time, not recomputed on the request hot path
- explicit separators prevent accidental ambiguity between adjacent fields

Suggested shape:

```rust
pub struct Provider {
    target: Target,
    weight: u32,
    limiter: ConcurrencyLimiter,
    identity: String,
}

impl Provider {
    pub fn identity(&self) -> &str {
        &self.identity
    }
}
```

## Affinity Key

The affinity binding key should be:

```text
(requested_model_alias, session_fingerprint)
```

The value is:

```text
provider_id
```

Where:

- `requested_model_alias` is the model name requested by the client
- `session_fingerprint` is derived from either explicit `session_id` or `Authorization`

The mapping must use the client-requested model alias, not the provider-rewritten `onwards_model`.

## Session Identity Resolution

V1 uses the following steps to derive session input:

1. Read the configured session header and treat a non-empty value as `session_id`.
2. Read `Authorization: Bearer <token>` and treat a valid bearer token as `authorization`.
3. If neither exists, affinity is skipped.

This keeps the feature named `session affinity` while still supporting clients that do not explicitly send a session id.

Header handling requirements:

- HTTP header names are case-insensitive
- `header_name` should be normalized once during config loading
- request handling should not perform repeated header-name normalization on every request
- empty or whitespace-only session header values should be treated as missing
- if multiple values are present for the same header, use the effective value returned by the HTTP framework and verify that behavior in tests
- bearer token extraction should treat the `Bearer` scheme case-insensitively
- leading and trailing whitespace around the extracted token should be trimmed
- non-`Bearer` authorization schemes should be ignored for affinity fallback

## Fingerprinting

Raw `session_id` and raw bearer tokens should not be used directly in logs, metrics, or cache keys exposed outside process memory.

Recommended v1 approach:

```text
session_fingerprint = SHA256(session_identity)
```

Recommended composition rule:

```text
if session_id and authorization:
    session_identity = authorization + "|" + session_id
else if session_id:
    session_identity = session_id
else if authorization:
    session_identity = authorization
```

This composition rule is normative for v1. The proxy must not treat `session_id` as a globally sufficient affinity key when `Authorization` is also available.

Requirements:

- deterministic for the same identity
- non-reversible in operational surfaces
- safe to use as an in-memory or external-store key

V1 should not introduce a separate HMAC secret configuration.

## Runtime State

Add a shared store to `AppState`:

```rust
pub session_affinity_store: Arc<dyn SessionAffinityStore>
```

Suggested trait:

```rust
pub trait SessionAffinityStore: Send + Sync {
    fn get(&self, key: &AffinityKey) -> Option<AffinityEntry>;
    fn insert(&self, key: AffinityKey, entry: AffinityEntry, ttl: Duration);
    fn delete(&self, key: &AffinityKey);
    fn touch(&self, key: &AffinityKey, ttl: Duration);
    fn remove_stale_for_model(
        &self,
        model: &str,
        valid_provider_ids: &HashSet<String>,
    ) -> usize {
        0
    }
}

pub struct AffinityKey {
    pub model: String,
    pub session_fingerprint: String,
}

pub struct AffinityEntry {
    pub provider_id: String,
}
```

The store API should stay intentionally small:

- normal selection remains in `ProviderPool`
- affinity state remains in the store
- selection orchestration remains in the handler

This avoids coupling session state to the load balancer implementation.

V1 note:

- `touch()` is preferred over a dedicated `get_and_refresh()` API because it keeps the store interface small and works for both in-memory caches and external stores
- returning owned values is acceptable for v1 because provider ids are small; avoiding extra lifetime complexity is preferable here
- `AffinityEntry` intentionally does not expose TTL or expiration time; expiration remains a store implementation detail
- `touch(ttl)` refreshes TTL only when the key already exists
- `touch()` on a missing key is a silent no-op
- `remove_stale_for_model()` is optional for store implementations; the default no-op is suitable for shared external stores that prefer lazy cleanup only

Expected store behavior:

| Scenario | Expected behavior |
|----------|-------------------|
| `get()` finds an expired entry | Return `None`; cleanup may be eager or lazy |
| `insert()` on an existing key | Overwrite `provider_id` and refresh TTL |
| `delete()` on a missing key | Succeed silently |
| `touch()` on a missing key | Succeed silently with no creation |
| `remove_stale_for_model()` on unsupported store | Return `0` and leave cleanup to lazy lookup |

Single-instance implementation:

- in-memory TTL cache such as `moka::sync::Cache`, or `DashMap` plus cleanup

Multi-instance implementation:

- Redis or another shared external store

V1 should treat store capacity as an implementation detail of the default in-memory store, not as a per-pool config knob.

Current implementation note:

- the default in-memory store uses `DashMap`
- expired entries are evicted lazily on `get()`
- successful affinity reuse refreshes TTL via `touch(ttl)`
- hot reload can eagerly remove stale provider bindings for the in-memory store
- there is no background sweeper yet for expired entries; expiration remains lazy by default

## Applicability

If a model pool has `session_affinity` configured, affinity should apply to all requests that:

- resolve a model alias for provider selection
- route through the standard provider selection path

This includes:

- `/v1/chat/completions`
- `/v1/responses` when the request resolves a model
- `/v1/completions`
- `/v1/embeddings`
- other model-based passthrough routes supported by the proxy

This does not include:

- requests that do not resolve a model
- endpoints that bypass model-based provider selection

Chat completions remain the primary motivation, but the routing behavior should be consistent for the entire model pool once `session_affinity` is enabled.

## Request Flow

The affinity logic should live in the provider selection layer, not in a special-case route branch.

Proposed flow for any model-routed request:

1. Extract `model` as today.
2. Resolve pool and apply auth, routing rules, rate limits, and pool/key concurrency checks as today.
3. If `session_affinity` is not configured for the pool, skip affinity.
4. Read the configured session header as optional `session_id`.
5. Read `Authorization` as optional bearer token.
6. If neither exists, skip affinity and continue with the existing pool strategy.
7. Compute `session_fingerprint` using the composition rule:
   - `authorization + "|" + session_id` when both exist
   - `session_id` when only session id exists
   - `authorization` when only authorization exists
8. Construct `AffinityKey { model, session_fingerprint }`.
9. Look up the key in the affinity store.
10. If a bound provider exists and is still present in the current pool:
   - try that provider first
   - if it is at provider concurrency capacity, unavailable, or locally rate-limited, continue to normal selection
11. If no valid binding exists, use the existing pool selection logic.
12. If a provider successfully handles the request:
   - first bind via `insert(key, entry, ttl)`
   - successful reuse of the same bound provider can refresh TTL via `touch(key, ttl)`
   - successful fallback takeover can rebind via `insert(key, entry, ttl)` when allowed
13. If fallback selects a different provider and that provider succeeds:
   - rebind according to `rebind_on_fallback`

Affinity should only run after the request has passed existing authentication checks. It is not an authentication primitive.
When explicit `session_id` is present, it only affects routing stickiness and does not replace auth.

Concurrency note:

- preferred-provider selection must attempt to acquire the provider's concurrency guard first
- only if guard acquisition fails should the request fall back to normal selection
- once guard acquisition succeeds, the provider choice for that attempt is fixed

If the same session issues concurrent requests, races are acceptable as long as:

- each individual request selects a valid provider
- the final stored binding is one of the successfully used providers
- the store remains internally consistent

Provider existence checks should use a pool helper such as:

```rust
impl ProviderPool {
    pub fn get_provider_by_id(&self, provider_id: &str) -> Option<(usize, &Provider)> {
        self.providers
            .iter()
            .enumerate()
            .find(|(_, provider)| provider.identity() == provider_id)
    }
}
```

## Load Balancer Changes

`ProviderPool` should expose affinity-aware selection instead of forcing handler-level provider iteration.

Suggested additions in `src/load_balancer.rs`:

```rust
pub fn select_by_provider_id(
    &self,
    provider_id: &str,
    exclude: &HashSet<usize>,
) -> Option<(usize, &Target, ConcurrencyGuard)>;

pub fn select_iter_with_preferred(
    &self,
    preferred_provider_id: Option<&str>,
) -> SelectIter<'_>;
```

Behavior:

- if `preferred_provider_id` is provided and the provider is selectable, the iterator yields it first
- remaining attempts follow normal `strategy` and `fallback` behavior
- provider-level concurrency and local rate-limit checks still apply

This keeps affinity layered on top of the current load balancing strategy rather than replacing it.

An important implementation property is to preserve two explicit entry points:

- normal provider selection
- provider selection with a preferred bound provider

That keeps the code path clear and mirrors the strongest idea from external reference designs without inheriting their tighter coupling to a specific selector implementation.

`SelectIter` likely needs explicit preferred-provider state, for example:

```rust
pub struct SelectIter<'a> {
    pool: &'a ProviderPool,
    excluded: HashSet<usize>,
    max_attempts: usize,
    attempts: usize,
    with_replacement: bool,
    preferred: Option<usize>,
    preferred_tried: bool,
}
```

Expected `next()` behavior:

1. if `preferred` exists and has not yet been tried, attempt it first
2. if preferred selection fails, mark it as tried
3. all later attempts use the existing selection strategy

Additional rules:

- if `preferred` is already in `excluded`, treat it as already tried
- attempting `preferred` consumes one attempt, just like any other provider attempt
- once `preferred_tried` becomes true, it must not be revisited by the iterator

## Final Config Shape

For the first implementation, the configuration surface should be:

```rust
#[derive(Debug, Clone, Serialize, Deserialize, Default)]
pub struct SessionAffinityConfig {
    #[serde(default = "default_session_affinity_header_name")]
    pub header_name: String,

    #[serde(default = "default_session_affinity_ttl_secs")]
    pub ttl_secs: u64,

    #[serde(default = "default_session_affinity_rebind_on_fallback")]
    pub rebind_on_fallback: bool,
}
```

Attached at pool level:

```rust
pub struct PoolSpec {
    // existing fields...
    #[serde(default)]
    pub session_affinity: Option<SessionAffinityConfig>,
}
```

Semantics:

- absence of `session_affinity` means affinity is disabled
- presence of `session_affinity` means affinity is enabled for that model alias
- the configured header provides the explicit session discriminator
- `Authorization` is folded into the fingerprint whenever it exists
- TTL uses sliding expiration
- store capacity is an implementation detail of the default in-memory store

This is the recommended final v1 config because it is minimal, directly implementable, and does not expose extension points that the first release will not support.

## Handler Integration

The main integration point is `target_message_handler` in `src/handlers.rs`.

The handler already owns:

- model extraction
- request header access
- bearer token extraction
- pool resolution
- routing rules
- rate limiting
- request forwarding
- fallback loop

Affinity should be inserted after pool resolution and policy checks, but before provider iteration.

High-level integration:

1. Resolve the affinity config from the selected pool.
2. Build a `SessionContext` by reading the configured session header and falling back to bearer token extraction.
3. Compute the session fingerprint once and reuse it for routing, logs, and metrics.
4. Pass the preferred provider id into the pool selection iterator.
5. On successful upstream selection and request completion, update the mapping.

Because strict handlers call into `target_message_handler`, no separate affinity implementation is needed for strict mode.

This also means the affinity behavior is naturally backward compatible:

- models without `session_affinity` keep existing behavior
- requests without session identity keep existing behavior
- existing load balancing strategies continue to work unchanged

Suggested helper types:

```rust
pub struct SessionContext {
    pub fingerprint: String,
    pub source: SessionSource,
}

pub enum SessionSource {
    HeaderOnly,
    AuthorizationOnly,
    HeaderAndAuthorization,
    None,
}
```

## Fallback Semantics

Fallback behavior needs explicit rules or the affinity mapping will flap.

### Recommended semantics

- if the bound provider succeeds, keep the binding
- if the bound provider is locally unavailable for selection, temporarily bypass it for the current request and keep the old binding unless another provider successfully takes over and `rebind_on_fallback = true`
- if the bound provider fails and another provider is attempted but does not succeed, keep the old binding
- if another provider succeeds via fallback, update the binding to that provider when `rebind_on_fallback = true`
- if the bound provider is removed from config or no longer exists in the pool, discard the stale mapping and select normally

Explicit v1 decision:

- if a fallback request succeeds and rebinding occurs, the proxy does not automatically switch the session back to the original provider later
- returning to the original provider only happens if the current binding expires or a future successful fallback rebinds again
- no `rebind_cooldown_secs` is introduced in v1; if flapping appears in production, it should be added later based on observed behavior

### Why this matters

Updating the binding too early causes session churn under transient errors. Not updating it after successful takeover causes repeated attempts to a bad provider.

## TTL Semantics

Use sliding expiration:

- every successful request refreshes the TTL
- active sessions remain sticky
- inactive sessions age out naturally

Recommended initial value:

- `ttl_secs = 300` or `600`

Long TTLs improve cache locality but reduce rebalancing flexibility. Short TTLs preserve balance but weaken cache affinity.

## Concurrency and Streaming

### Concurrency

Affinity does not bypass existing pool-level or provider-level concurrency controls.

If the bound provider is full:

- prefer temporary fallback for the current request
- do not immediately rewrite the mapping unless the fallback provider successfully completes the request and rebind policy allows it

Tradeoff:

- immediate fallback is simple and keeps latency low
- in cache-sensitive workloads, immediate fallback may reduce cache hit rate and cause session flapping across providers

Future optimization:

- a bounded affinity wait such as `max_wait_ms` could allow short waiting on the bound provider before falling back
- v1 intentionally does not introduce queueing semantics at the affinity layer

### Streaming

Streaming requests should behave the same as non-streaming requests:

- provider choice is made once, before the upstream request is sent
- the stream remains on that provider for the lifetime of the request
- the affinity mapping can be refreshed as soon as the request has been accepted by the selected provider

V1 decision:

- refreshing TTL when the upstream accepts the HTTP request is acceptable

Future optimization:

- for streaming requests, TTL refresh could instead be delayed until the first valid upstream chunk is observed
- this would reduce the chance of extending affinity for a provider that accepts the connection but fails before meaningful output begins

V1 does not add this extra complexity.

## Hot Reload Semantics

Today, config reload preserves active connection counters but not affinity state.

That is acceptable only if the affinity store lives outside `Targets`.

Recommended approach:

- keep affinity state in `AppState`, not in `Targets`
- on each request, validate that the stored `provider_id` still exists in the current pool
- if it does not exist, delete the stale mapping and fall back to normal selection

Implemented single-process optimization:

- the default in-memory store participates in eager stale cleanup after successful config reload
- cleanup is model-scoped and removes bindings whose `provider_id` is no longer valid in the new local pool view
- deleted models are also cleaned if they previously had affinity-enabled pools
- request-path lazy validation remains the correctness fallback even when eager cleanup runs

Distributed deployment rule:

- when using an external shared store such as Redis across multiple gateway instances, use lazy cleanup only
- avoid eager cleanup during config reload in shared-store mode because different instances may observe the new provider set at slightly different times
- stale bindings should only be removed when the current instance validates that the bound provider no longer exists in its active pool view

This keeps affinity stable across config reloads while remaining robust to provider removal or identity changes.

## Deployment Modes

### Single instance

Use an in-memory TTL cache. This is the simplest implementation and likely sufficient for development or a single gateway node.

### Multiple gateway instances

Use a shared external store. Otherwise the same logical session may hit different gateway replicas and receive different provider bindings.

For multi-instance deployments, session affinity should be considered incomplete unless:

- requests are already pinned to one gateway instance by an outer load balancer, or
- the affinity store is externalized

## Observability

Add logs and metrics for:

- affinity lookup hit
- affinity lookup miss
- stale mapping detected
- bound provider unavailable
- fallback from bound provider
- successful rebind
- reload-time stale cleanup

Suggested metric dimensions:

- `model`
- `result`

Suggested counters or events:

- total affinity lookups
- affinity hit ratio
- rebind count
- stale-binding eviction count
- fallback-after-affinity count

Current metric set for `session_affinity_total{model, result}`:

- `hit`
- `miss`
- `stale`
- `bound`
- `rebound`
- `unavailable`
- `error`
- `fallback_no_rebind`

Definitions:

- `hit`: affinity binding existed and the bound provider was selected
- `miss`: no affinity binding existed
- `stale`: affinity binding existed but pointed to a provider no longer valid in the current pool
- `bound`: no prior binding existed and the request successfully created one
- `rebound`: a different provider succeeded and the binding was updated
- `unavailable`: the bound provider existed but could not be selected locally, for example due to concurrency or local rate limits
- `error`: the bound provider was selected but failed at the upstream interaction stage
- `fallback_no_rebind`: fallback succeeded but the binding was intentionally preserved because `rebind_on_fallback = false`

Cleanup metrics:

- `session_affinity_cleanup_total{model, reason="reload"}`

Do not emit raw `session_id`, raw bearer tokens, derived fingerprints, or `provider_id` as metric labels.

Reasoning:

- `provider_id` is safe enough for targeted debug logging if needed
- `provider_id` should still stay out of metric labels in v1 to keep cardinality low and metrics stable
- separate `unavailable` from `error` makes it easier to distinguish local selection failure from upstream failure after affinity hit
- `bound` distinguishes first-write success from ordinary misses
- cleanup is tracked separately because it is driven by config reload rather than request selection outcome

## External Reference Notes

The design is informed by ideas seen in other projects that support multi-key or multi-upstream session stickiness.

The most useful ideas to keep are:

- session binding should be configured independently from the base selection strategy
- the implementation should expose both a normal selection path and a session-aware selection path
- TTL and expiration behavior should be explicit
- validation and testing should be part of the design, not an afterthought

The ideas intentionally not adopted are:

- exposing a broad `source = auto` style configuration in v1
- coupling affinity state directly into a selector-specific in-memory map
- replacing the existing load balancing strategy with a dedicated affinity strategy

This keeps the design aligned with Onwards' current architecture, where provider selection, fallback, and config reload are already more sophisticated than a simple multi-key round-robin selector.

## Risks and Tradeoffs

### Authorization fallback is not always a real end-user identity

If many users share one API key and no explicit `session_id` is provided, the affinity behavior is effectively per key, not per end user.

This is acceptable for cache affinity, but the semantic scope must be documented clearly.

### Explicit session id alone can be unsafe in multi-tenant deployments

If explicit `session_id` were used as the sole affinity input even when `Authorization` is present, different callers could intentionally or accidentally collide onto the same affinity bucket.

V1 avoids this by folding `Authorization` into the fingerprint whenever both values are present.

### Affinity can create hotspots

High-throughput sessions may stick to one provider and reduce balance quality. This is an intentional tradeoff in exchange for higher cache hit rates.

### Missing session identity disables affinity

That is acceptable. Requests should degrade to the current routing behavior.

### Provider identity changes invalidate bindings

Changing a provider's `url`, `onwards_key`, or `onwards_model` changes its derived identity.

This invalidates bindings for sessions previously attached to that provider and can cause a temporary cache miss wave after config reload.

V1 accepts this tradeoff because identity changes may represent a materially different upstream target or account boundary.

## Testing Plan

Add tests covering:

1. first request with explicit `session_id` creates a binding
2. subsequent request with same `(model, session_id)` reuses the same provider
3. missing `session_id` falls back to `Authorization`
4. same `(model, authorization)` reuses the same provider when no `session_id` is present
5. different explicit session ids can route to different providers
6. missing both `session_id` and `Authorization` preserves existing load balancing behavior
7. the same affinity behavior applies to `/chat/completions`, `/responses`, `/completions`, and `/embeddings` when they resolve the same model alias
8. bound provider removed on config reload causes lazy rebinding
9. bound provider at concurrency capacity falls back without crashing
10. fallback success updates binding when rebind is enabled
11. fallback success does not update binding when rebind is disabled
12. strict-mode handlers use the same affinity behavior
13. streaming requests preserve provider affinity
14. invalid `session_affinity` config is rejected at load time
15. header name matching behaves correctly regardless of request header casing
16. concurrent requests for the same session behave consistently
17. in-memory cleanup removes expired entries under load
18. config reload preserves valid bindings and eagerly cleans stale bindings for the default in-memory store while preserving lazy cleanup as fallback
19. after TTL expiration, the next request falls back to normal selection
20. concurrent requests creating the same session binding behave correctly
21. provider identity change caused by url/key/model change triggers lazy rebinding
22. large-session-count tests validate memory and latency characteristics
23. the same session issuing requests with sub-millisecond spacing behaves correctly
24. preferred provider selection is unaffected by provider weight once the provider is bound
25. session header values containing Unicode or special characters produce stable fingerprints
26. explicit `session_id` from different authorization tokens does not collide into the same affinity bucket

## Rollout Plan

1. add config types and internal stable provider identity
2. add store abstraction and default in-memory implementation
3. add config validation helpers
4. add session identity extraction and fingerprinting helper
5. extend `ProviderPool` with preferred-provider selection and `get_provider_by_id()`
6. integrate affinity into `target_message_handler`
7. add metrics and logs
8. add tests for passthrough, strict mode, streaming, concurrency, and reload
9. document multi-instance requirements before enabling in production

## Suggested Code Layout

To keep the implementation isolated, session affinity code should live in a dedicated module:

```text
src/
  session_affinity/
    mod.rs
    context.rs
    key.rs
    store.rs
    metrics.rs
```

Suggested responsibilities:

- `mod.rs`: public types and trait definitions
- `context.rs`: session extraction and `SessionContext`
- `key.rs`: session identity extraction and fingerprinting
- `store.rs`: in-memory store implementation
- `metrics.rs`: counters and helper recording functions

`key.rs` should own:

- `AffinityKey`
- session fingerprint computation
- provider identity computation

`compute_provider_id()` should preferably be exposed as a method on `Target` or `Provider` rather than as an unrelated free function.

## Optional Feature Flag

A Cargo feature flag is optional if the team wants to isolate the dependency footprint:

```toml
[features]
default = ["session-affinity"]
session-affinity = []
```

This is not required for v1 and should only be added if dependency management or rollout strategy makes it worthwhile.

## Recommended Minimal Implementation

For the first iteration:

- apply to all model-routed provider selection
- prefer explicit `session_id` and fall back to `Authorization`
- use pool-level opt-in config
- use an in-memory TTL cache by default
- use sliding TTL refresh
- support rebinding on successful fallback
- keep the feature best-effort and fail-open

This gives the expected cache-affinity behavior with minimal disruption to the existing architecture.