### PR TITLE
feat: backfill missing strict responses fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1576,6 +1576,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "url",
+ "uuid",
  "wiremock",
 ]
 
@@ -2890,6 +2891,7 @@ version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ axum-prometheus = "0.10.0"
 metrics = "0.24"
 governor = "0.10.1"
 rand = "0.9"
+uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 axum-test = "18.0.0"

--- a/src/strict/handlers.rs
+++ b/src/strict/handlers.rs
@@ -1848,10 +1848,10 @@ async fn sanitize_streaming_responses_response(
                             continue;
                         }
 
-                        // Parse as a typed ResponsesStreamingEvent — the structured
-                        // envelope shared by all Responses API streaming events.
-                        // This validates that type + sequence_number are present and
-                        // gives us typed access to response.model for rewriting.
+                        // Parse into JSON first so we can normalize sparse provider
+                        // payloads, then coerce into the typed ResponsesStreamingEvent
+                        // envelope to validate type/sequence_number and rewrite the
+                        // nested response model safely.
                         let mut raw_event: serde_json::Value = match serde_json::from_str(data_part)
                         {
                             Ok(event) => event,

--- a/src/strict/handlers.rs
+++ b/src/strict/handlers.rs
@@ -6016,6 +6016,39 @@ mod tests {
         assert_eq!(json["choices"][1]["index"], 1);
     }
 
+    #[tokio::test]
+    async fn test_strict_sanitize_completions_does_not_backfill_generated_text() {
+        let mock_response = r#"{
+            "choices": [{"finish_reason": "stop"}]
+        }"#;
+
+        let mock_client = MockHttpClient::new(StatusCode::OK, mock_response);
+        let state = AppState::with_client(
+            completions_test_targets("gpt-3.5-turbo-instruct"),
+            mock_client,
+        );
+        let router = crate::strict::build_strict_router(state);
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/completions")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"model":"gpt-3.5-turbo-instruct","prompt":"Say hello"}"#,
+            ))
+            .unwrap();
+
+        let response = router.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(json["error"]["type"], "api_error");
+    }
+
     /// Content-Length header is corrected after sanitization shrinks the body
     #[tokio::test]
     async fn test_completions_sanitization_updates_content_length_header() {
@@ -6243,6 +6276,43 @@ mod tests {
         assert!(body_str.contains("\"index\":0"));
         assert!(body_str.contains("\"text\":\"Hello\""));
         assert!(body_str.contains("\"id\":\"cmpl-"));
+        assert!(body_str.contains("[DONE]"));
+    }
+
+    #[tokio::test]
+    async fn test_strict_sanitize_completions_streaming_backfills_missing_chunk_text() {
+        let mock_client = MockHttpClient::new_streaming(
+            StatusCode::OK,
+            vec![
+                "data: {\"choices\":[{\"finish_reason\":null}]}\n\n".to_string(),
+                "data: [DONE]\n\n".to_string(),
+            ],
+        );
+        let state = AppState::with_client(
+            completions_test_targets("gpt-3.5-turbo-instruct"),
+            mock_client,
+        );
+        let router = crate::strict::build_strict_router(state);
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/completions")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"model":"gpt-3.5-turbo-instruct","prompt":"Hello","stream":true}"#,
+            ))
+            .unwrap();
+
+        let response = router.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body_str = String::from_utf8(body.to_vec()).unwrap();
+
+        assert!(body_str.contains("\"text\":\"\""));
+        assert!(body_str.contains("\"index\":0"));
         assert!(body_str.contains("[DONE]"));
     }
 

--- a/src/strict/handlers.rs
+++ b/src/strict/handlers.rs
@@ -12,13 +12,18 @@
 use super::adapter::{OpenResponsesAdapter, PendingToolCall};
 use super::schemas::chat_completions::{
     ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse, ChatMessage, FunctionCall,
-    FunctionDefinition, Tool as ChatTool, ToolCall, Usage,
+    FunctionDefinition, Tool as ChatTool, ToolCall, Usage, generated_chat_completion_id,
+    normalize_chat_completion_chunk_value, normalize_chat_completion_response_value,
 };
-use super::schemas::completions::{CompletionChunk, CompletionRequest, CompletionResponse};
+use super::schemas::completions::{
+    CompletionChunk, CompletionRequest, CompletionResponse, generated_completion_id,
+    normalize_completion_chunk_value, normalize_completion_response_value,
+};
 use super::schemas::embeddings::{EmbeddingsRequest, EmbeddingsResponse};
 use super::schemas::responses::{
     InputTokensDetails, OutputTokensDetails, ResponseUsage, ResponsesRequest, ResponsesResponse,
-    ResponsesStreamingEvent,
+    ResponsesStreamingEvent, generated_response_id, normalize_responses_response_value,
+    normalize_responses_streaming_event_value,
 };
 use super::streaming::{StreamingState, parse_chat_chunk};
 use crate::AppState;
@@ -1248,8 +1253,7 @@ async fn sanitize_chat_response(mut response: Response, original_model: String) 
         }
     };
 
-    // Deserialize through our strict schema (automatically drops extra fields)
-    let mut chat_response: ChatCompletionResponse = match serde_json::from_slice(&body_bytes) {
+    let mut raw_response: serde_json::Value = match serde_json::from_slice(&body_bytes) {
         Ok(resp) => resp,
         Err(e) => {
             // Failed to deserialize - provider returned malformed response
@@ -1258,6 +1262,20 @@ async fn sanitize_chat_response(mut response: Response, original_model: String) 
                 error = %e,
                 body_sample = ?String::from_utf8_lossy(&body_bytes).chars().take(200).collect::<String>(),
                 "Failed to deserialize chat response from provider, returning standard error"
+            );
+            return error_response(StatusCode::BAD_GATEWAY, "api_error", "Bad gateway");
+        }
+    };
+
+    normalize_chat_completion_response_value(&mut raw_response, &original_model);
+
+    // Deserialize through our strict schema (automatically drops extra fields)
+    let mut chat_response: ChatCompletionResponse = match serde_json::from_value(raw_response) {
+        Ok(resp) => resp,
+        Err(e) => {
+            error!(
+                error = %e,
+                "Failed to coerce chat response into strict schema"
             );
             return error_response(StatusCode::BAD_GATEWAY, "api_error", "Bad gateway");
         }
@@ -1326,6 +1344,7 @@ async fn sanitize_streaming_chat_response(
     let body_stream =
         http_body_util::BodyExt::into_data_stream(std::mem::take(response.body_mut()));
     let buffered_stream = crate::sse::SseBufferedStream::new(body_stream);
+    let stream_fallback_id = generated_chat_completion_id();
 
     let sanitized_stream = buffered_stream.map(move |chunk_result| {
         match chunk_result {
@@ -1346,7 +1365,36 @@ async fn sanitize_streaming_chat_response(
                         }
 
                         // Deserialize the chunk through our strict schema
-                        match serde_json::from_str::<ChatCompletionChunk>(data_part) {
+                        let mut raw_chunk: serde_json::Value = match serde_json::from_str(data_part)
+                        {
+                            Ok(chunk) => chunk,
+                            Err(e) => {
+                                if let Some(error_event) = try_format_sse_error(data_part, trusted) {
+                                    error!(
+                                        data_sample = ?data_part.chars().take(200).collect::<String>(),
+                                        "Provider returned error object inside SSE stream, forwarding as error event"
+                                    );
+                                    sanitized_lines.push(error_event);
+                                    continue;
+                                }
+                                error!(
+                                    error = %e,
+                                    data_sample = ?data_part.chars().take(200).collect::<String>(),
+                                    "Failed to parse SSE data line from provider, terminating stream"
+                                );
+                                return Err(std::io::Error::other(
+                                    "Malformed SSE data from provider",
+                                ));
+                            }
+                        };
+
+                        normalize_chat_completion_chunk_value(
+                            &mut raw_chunk,
+                            &original_model,
+                            &stream_fallback_id,
+                        );
+
+                        match serde_json::from_value::<ChatCompletionChunk>(raw_chunk) {
                             Ok(mut chunk_data) => {
                                 // Rewrite model field
                                 chunk_data.model = original_model.clone();
@@ -1365,10 +1413,6 @@ async fn sanitize_streaming_chat_response(
                                 }
                             }
                             Err(e) => {
-                                // Check if this is a provider error object embedded
-                                // in the SSE stream (e.g. input too long, invalid model).
-                                // Forward it as a clean SSE event so callers can
-                                // distinguish it from a network/parse error.
                                 if let Some(error_event) = try_format_sse_error(data_part, trusted) {
                                     error!(
                                         data_sample = ?data_part.chars().take(200).collect::<String>(),
@@ -1444,13 +1488,26 @@ async fn sanitize_completions_response(mut response: Response, original_model: S
             }
         };
 
-    let mut completion_response: CompletionResponse = match serde_json::from_slice(&body_bytes) {
+    let mut raw_response: serde_json::Value = match serde_json::from_slice(&body_bytes) {
         Ok(resp) => resp,
         Err(e) => {
             error!(
                 error = %e,
                 body_sample = ?String::from_utf8_lossy(&body_bytes).chars().take(200).collect::<String>(),
                 "Failed to deserialize completions response from provider, returning standard error"
+            );
+            return error_response(StatusCode::BAD_GATEWAY, "api_error", "Bad gateway");
+        }
+    };
+
+    normalize_completion_response_value(&mut raw_response, &original_model);
+
+    let mut completion_response: CompletionResponse = match serde_json::from_value(raw_response) {
+        Ok(resp) => resp,
+        Err(e) => {
+            error!(
+                error = %e,
+                "Failed to coerce completions response into strict schema"
             );
             return error_response(StatusCode::BAD_GATEWAY, "api_error", "Bad gateway");
         }
@@ -1498,6 +1555,7 @@ async fn sanitize_streaming_completions_response(
     let body_stream =
         http_body_util::BodyExt::into_data_stream(std::mem::take(response.body_mut()));
     let buffered_stream = crate::sse::SseBufferedStream::new(body_stream);
+    let stream_fallback_id = generated_completion_id();
 
     let sanitized_stream = buffered_stream.map(move |chunk_result| {
         match chunk_result {
@@ -1512,7 +1570,36 @@ async fn sanitize_streaming_completions_response(
                             continue;
                         }
 
-                        match serde_json::from_str::<CompletionChunk>(data_part) {
+                        let mut raw_chunk: serde_json::Value = match serde_json::from_str(data_part)
+                        {
+                            Ok(chunk) => chunk,
+                            Err(e) => {
+                                if let Some(error_event) = try_format_sse_error(data_part, trusted) {
+                                    error!(
+                                        data_sample = ?data_part.chars().take(200).collect::<String>(),
+                                        "Provider returned error object inside SSE stream, forwarding as error event"
+                                    );
+                                    sanitized_lines.push(error_event);
+                                    continue;
+                                }
+                                error!(
+                                    error = %e,
+                                    raw = %data_part.chars().take(200).collect::<String>(),
+                                    "Failed to parse completions chunk, terminating stream"
+                                );
+                                return Err(std::io::Error::other(
+                                    "Malformed SSE data from provider",
+                                ));
+                            }
+                        };
+
+                        normalize_completion_chunk_value(
+                            &mut raw_chunk,
+                            &original_model,
+                            &stream_fallback_id,
+                        );
+
+                        match serde_json::from_value::<CompletionChunk>(raw_chunk) {
                             Ok(mut chunk_data) => {
                                 chunk_data.model = original_model.clone();
                                 match serde_json::to_string(&chunk_data) {
@@ -1662,7 +1749,7 @@ async fn sanitize_responses_response(mut response: Response, original_model: Str
             }
         };
 
-    let mut responses_response: ResponsesResponse = match serde_json::from_slice(&body_bytes) {
+    let mut raw_response: serde_json::Value = match serde_json::from_slice(&body_bytes) {
         Ok(resp) => resp,
         Err(e) => {
             error!(
@@ -1670,6 +1757,20 @@ async fn sanitize_responses_response(mut response: Response, original_model: Str
                 body_sample = ?String::from_utf8_lossy(&body_bytes).chars().take(200).collect::<String>(),
                 "Failed to deserialize responses API response from provider, returning standard error"
             );
+            return error_response(StatusCode::BAD_GATEWAY, "api_error", "Bad gateway");
+        }
+    };
+
+    // Keep this provider-specific backfill in the sanitizer layer instead of
+    // putting serde defaults on `ResponsesResponse`. Struct-level defaults
+    // would relax all deserialize paths, while strict mode only wants to be
+    // forgiving when shaping third-party payloads into our public schema.
+    normalize_responses_response_value(&mut raw_response, &original_model);
+
+    let mut responses_response: ResponsesResponse = match serde_json::from_value(raw_response) {
+        Ok(resp) => resp,
+        Err(e) => {
+            error!(error = %e, "Failed to coerce responses API response into strict schema");
             return error_response(StatusCode::BAD_GATEWAY, "api_error", "Bad gateway");
         }
     };
@@ -1728,6 +1829,7 @@ async fn sanitize_streaming_responses_response(
     let body_stream =
         http_body_util::BodyExt::into_data_stream(std::mem::take(response.body_mut()));
     let buffered_stream = crate::sse::SseBufferedStream::new(body_stream);
+    let stream_fallback_response_id = generated_response_id();
 
     let sanitized_stream = buffered_stream.map(move |chunk_result| {
         match chunk_result {
@@ -1750,7 +1852,36 @@ async fn sanitize_streaming_responses_response(
                         // envelope shared by all Responses API streaming events.
                         // This validates that type + sequence_number are present and
                         // gives us typed access to response.model for rewriting.
-                        match serde_json::from_str::<ResponsesStreamingEvent>(data_part) {
+                        let mut raw_event: serde_json::Value = match serde_json::from_str(data_part)
+                        {
+                            Ok(event) => event,
+                            Err(e) => {
+                                if let Some(error_event) = try_format_sse_error(data_part, trusted) {
+                                    error!(
+                                        data_sample = ?data_part.chars().take(200).collect::<String>(),
+                                        "Provider returned error object inside SSE stream, forwarding as error event"
+                                    );
+                                    sanitized_lines.push(error_event);
+                                    continue;
+                                }
+                                error!(
+                                    error = %e,
+                                    data_sample = ?data_part.chars().take(200).collect::<String>(),
+                                    "Failed to parse responses SSE data line from provider, terminating stream"
+                                );
+                                return Err(std::io::Error::other(
+                                    "Malformed SSE data from provider",
+                                ));
+                            }
+                        };
+
+                        normalize_responses_streaming_event_value(
+                            &mut raw_event,
+                            &original_model,
+                            &stream_fallback_response_id,
+                        );
+
+                        match serde_json::from_value::<ResponsesStreamingEvent>(raw_event) {
                             Ok(mut event) => {
                                 // Rewrite model on response-level events
                                 if let Some(ref mut response) = event.response {
@@ -2163,6 +2294,119 @@ mod tests {
         assert!(!body_str.contains("gpt-4-turbo-2024-04-09"));
     }
 
+    #[tokio::test]
+    async fn test_strict_sanitize_chat_backfills_missing_noncritical_fields() {
+        let targets = Arc::new(DashMap::new());
+        targets.insert(
+            "gpt-4".to_string(),
+            Target::builder()
+                .url("https://api.openai.com/v1/".parse().unwrap())
+                .onwards_key("sk-test".to_string())
+                .build()
+                .into_pool(),
+        );
+
+        let targets = Targets {
+            targets,
+            key_rate_limiters: Arc::new(DashMap::new()),
+            key_concurrency_limiters: Arc::new(DashMap::new()),
+            key_labels: Arc::new(DashMap::new()),
+            strict_mode: true,
+            http_pool_config: None,
+        };
+
+        let mock_response = r#"{
+            "choices": [{
+                "message": {
+                    "content": "Hello from downstream"
+                }
+            }]
+        }"#;
+
+        let mock_client = MockHttpClient::new(StatusCode::OK, mock_response);
+        let state = AppState::with_client(targets, mock_client);
+        let router = crate::strict::build_strict_router(state);
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/chat/completions")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"model":"gpt-4","messages":[{"role":"user","content":"Hello"}]}"#,
+            ))
+            .unwrap();
+
+        let response = router.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(json["model"], "gpt-4");
+        assert_eq!(json["object"], "chat.completion");
+        let id = json["id"].as_str().expect("id should be a string");
+        assert!(id.starts_with("chatcmpl-"));
+        assert_eq!(json["choices"][0]["index"], 0);
+        assert_eq!(json["choices"][0]["message"]["role"], "assistant");
+        assert_eq!(
+            json["choices"][0]["message"]["content"],
+            "Hello from downstream"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_strict_sanitize_chat_backfills_choice_indexes_from_position() {
+        let targets = Arc::new(DashMap::new());
+        targets.insert(
+            "gpt-4".to_string(),
+            Target::builder()
+                .url("https://api.openai.com/v1/".parse().unwrap())
+                .onwards_key("sk-test".to_string())
+                .build()
+                .into_pool(),
+        );
+
+        let targets = Targets {
+            targets,
+            key_rate_limiters: Arc::new(DashMap::new()),
+            key_concurrency_limiters: Arc::new(DashMap::new()),
+            key_labels: Arc::new(DashMap::new()),
+            strict_mode: true,
+            http_pool_config: None,
+        };
+
+        let mock_response = r#"{
+            "choices": [
+                {"message": {"content": "first"}},
+                {"message": {"content": "second"}}
+            ]
+        }"#;
+
+        let mock_client = MockHttpClient::new(StatusCode::OK, mock_response);
+        let state = AppState::with_client(targets, mock_client);
+        let router = crate::strict::build_strict_router(state);
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/chat/completions")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"model":"gpt-4","messages":[{"role":"user","content":"Hello"}]}"#,
+            ))
+            .unwrap();
+
+        let response = router.oneshot(request).await.unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(json["choices"][0]["index"], 0);
+        assert_eq!(json["choices"][1]["index"], 1);
+    }
+
     /// Test that streaming responses drop extra fields from third parties
     #[tokio::test]
     async fn test_strict_sanitize_streaming_removes_unknown_fields() {
@@ -2272,6 +2516,174 @@ mod tests {
         // Model should be rewritten to client-requested model
         assert!(body_str.contains("\"model\":\"gpt-4\""));
         assert!(!body_str.contains("gpt-4-turbo"));
+    }
+
+    #[tokio::test]
+    async fn test_strict_sanitize_streaming_chat_backfills_missing_noncritical_fields() {
+        let targets = Arc::new(DashMap::new());
+        targets.insert(
+            "gpt-4".to_string(),
+            Target::builder()
+                .url("https://api.openai.com/v1/".parse().unwrap())
+                .onwards_key("sk-test".to_string())
+                .build()
+                .into_pool(),
+        );
+
+        let targets = Targets {
+            targets,
+            key_rate_limiters: Arc::new(DashMap::new()),
+            key_concurrency_limiters: Arc::new(DashMap::new()),
+            key_labels: Arc::new(DashMap::new()),
+            strict_mode: true,
+            http_pool_config: None,
+        };
+
+        let streaming_chunks = vec![
+            r#"data: {"choices":[{"delta":{"content":"Hello"}}]}
+
+"#
+            .to_string(),
+            "data: [DONE]\n\n".to_string(),
+        ];
+
+        let mock_client = MockHttpClient::new_streaming(StatusCode::OK, streaming_chunks);
+        let state = AppState::with_client(targets, mock_client);
+        let router = crate::strict::build_strict_router(state);
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/chat/completions")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"model":"gpt-4","messages":[{"role":"user","content":"Hello"}],"stream":true}"#,
+            ))
+            .unwrap();
+
+        let response = router.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body_str = String::from_utf8(body.to_vec()).unwrap();
+
+        assert!(body_str.contains("\"object\":\"chat.completion.chunk\""));
+        assert!(body_str.contains("\"model\":\"gpt-4\""));
+        assert!(body_str.contains("\"index\":0"));
+        assert!(body_str.contains("\"content\":\"Hello\""));
+        assert!(body_str.contains("\"id\":\"chatcmpl-"));
+        assert!(body_str.contains("[DONE]"));
+    }
+
+    #[tokio::test]
+    async fn test_strict_sanitize_streaming_chat_backfills_chunk_indexes_from_position() {
+        let targets = Arc::new(DashMap::new());
+        targets.insert(
+            "gpt-4".to_string(),
+            Target::builder()
+                .url("https://api.openai.com/v1/".parse().unwrap())
+                .onwards_key("sk-test".to_string())
+                .build()
+                .into_pool(),
+        );
+
+        let targets = Targets {
+            targets,
+            key_rate_limiters: Arc::new(DashMap::new()),
+            key_concurrency_limiters: Arc::new(DashMap::new()),
+            key_labels: Arc::new(DashMap::new()),
+            strict_mode: true,
+            http_pool_config: None,
+        };
+
+        let streaming_chunks = vec![
+            r#"data: {"choices":[{"delta":{"content":"first"}},{"delta":{"content":"second"}}]}
+
+"#
+            .to_string(),
+            "data: [DONE]\n\n".to_string(),
+        ];
+
+        let mock_client = MockHttpClient::new_streaming(StatusCode::OK, streaming_chunks);
+        let state = AppState::with_client(targets, mock_client);
+        let router = crate::strict::build_strict_router(state);
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/chat/completions")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"model":"gpt-4","messages":[{"role":"user","content":"Hello"}],"stream":true}"#,
+            ))
+            .unwrap();
+
+        let response = router.oneshot(request).await.unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body_str = String::from_utf8(body.to_vec()).unwrap();
+
+        assert!(body_str.contains("\"index\":0"));
+        assert!(body_str.contains("\"index\":1"));
+    }
+
+    #[tokio::test]
+    async fn test_strict_sanitize_streaming_chat_reuses_fallback_id_across_chunks() {
+        let targets = Arc::new(DashMap::new());
+        targets.insert(
+            "gpt-4".to_string(),
+            Target::builder()
+                .url("https://api.openai.com/v1/".parse().unwrap())
+                .onwards_key("sk-test".to_string())
+                .build()
+                .into_pool(),
+        );
+
+        let targets = Targets {
+            targets,
+            key_rate_limiters: Arc::new(DashMap::new()),
+            key_concurrency_limiters: Arc::new(DashMap::new()),
+            key_labels: Arc::new(DashMap::new()),
+            strict_mode: true,
+            http_pool_config: None,
+        };
+
+        let streaming_chunks = vec![
+            "data: {\"choices\":[{\"delta\":{\"content\":\"first\"}}]}\n\n".to_string(),
+            "data: {\"choices\":[{\"delta\":{\"content\":\"second\"}}]}\n\n".to_string(),
+            "data: [DONE]\n\n".to_string(),
+        ];
+
+        let mock_client = MockHttpClient::new_streaming(StatusCode::OK, streaming_chunks);
+        let state = AppState::with_client(targets, mock_client);
+        let router = crate::strict::build_strict_router(state);
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/chat/completions")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"model":"gpt-4","messages":[{"role":"user","content":"Hello"}],"stream":true}"#,
+            ))
+            .unwrap();
+
+        let response = router.oneshot(request).await.unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body_str = String::from_utf8(body.to_vec()).unwrap();
+
+        let ids: Vec<String> = body_str
+            .lines()
+            .filter_map(|line| line.strip_prefix("data: "))
+            .filter(|data| *data != "[DONE]")
+            .map(|data| serde_json::from_str::<serde_json::Value>(data).unwrap())
+            .filter_map(|json| json.get("id").and_then(|v| v.as_str()).map(str::to_string))
+            .collect();
+
+        assert!(ids.len() >= 2);
+        assert!(ids.iter().all(|id| id == &ids[0]));
     }
 
     #[tokio::test]
@@ -2853,6 +3265,76 @@ mod tests {
         assert!(!body_str.contains("gpt-4o-2024-05-13"));
     }
 
+    /// Test that responses API fills omitted non-critical fields instead of failing strict-mode sanitization.
+    #[tokio::test]
+    async fn test_strict_sanitize_responses_backfills_missing_noncritical_fields() {
+        let targets = Arc::new(DashMap::new());
+        targets.insert(
+            "gpt-4o".to_string(),
+            Target::builder()
+                .url("https://api.openai.com/v1/".parse().unwrap())
+                .onwards_key("sk-test".to_string())
+                .build()
+                .into_pool(),
+        );
+
+        let targets = Targets {
+            targets,
+            key_rate_limiters: Arc::new(DashMap::new()),
+            key_concurrency_limiters: Arc::new(DashMap::new()),
+            key_labels: Arc::new(DashMap::new()),
+            strict_mode: true,
+            http_pool_config: None,
+        };
+
+        // Provider omits bookkeeping fields that are required by our strict schema,
+        // but the actual generation is present in output.
+        let mock_response = r#"{
+            "id": "resp_abc123",
+            "created_at": 1677652288,
+            "model": "provider-model",
+            "output": [{
+                "type": "message",
+                "role": "assistant",
+                "content": [{
+                    "type": "output_text",
+                    "text": "Hello from downstream"
+                }]
+            }]
+        }"#;
+
+        let mock_client = MockHttpClient::new(StatusCode::OK, mock_response);
+        let state = AppState::with_client(targets, mock_client);
+        let router = crate::strict::build_strict_router(state);
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/responses")
+            .header("content-type", "application/json")
+            .body(Body::from(r#"{"model":"gpt-4o","input":"Hello"}"#))
+            .unwrap();
+
+        let response = router.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(json["id"], "resp_abc123");
+        assert_eq!(json["model"], "gpt-4o");
+        assert_eq!(json["object"], "response");
+        assert_eq!(json["status"], "completed");
+        assert_eq!(json["tool_choice"], "auto");
+        assert_eq!(json["parallel_tool_calls"], true);
+        assert_eq!(json["usage"], serde_json::Value::Null);
+        assert_eq!(
+            json["output"][0]["content"][0]["text"],
+            "Hello from downstream"
+        );
+    }
+
     /// Test that responses API errors are sanitized
     #[tokio::test]
     async fn test_strict_sanitize_responses_error() {
@@ -3032,6 +3514,207 @@ mod tests {
             response_str.contains("\"delta\":\"Hello\""),
             "delta field should pass through on delta events"
         );
+    }
+
+    #[tokio::test]
+    async fn test_strict_sanitize_responses_streaming_backfills_missing_noncritical_fields() {
+        let targets = Arc::new(DashMap::new());
+        targets.insert(
+            "gpt-4o".to_string(),
+            Target::builder()
+                .url("https://api.openai.com/v1/".parse().unwrap())
+                .onwards_key("sk-test".to_string())
+                .build()
+                .into_pool(),
+        );
+
+        let targets = Targets {
+            targets,
+            key_rate_limiters: Arc::new(DashMap::new()),
+            key_concurrency_limiters: Arc::new(DashMap::new()),
+            key_labels: Arc::new(DashMap::new()),
+            strict_mode: true,
+            http_pool_config: None,
+        };
+
+        let mock_stream = concat!(
+            "data: {\"type\":\"response.created\",\"sequence_number\":0,\"response\":{",
+            "\"id\":\"resp-123\",\"created_at\":1677652288,\"model\":\"provider-model\"}}\n\n",
+            "data: {\"type\":\"response.output_text.delta\",\"sequence_number\":1,",
+            "\"item_id\":\"msg_abc\",\"output_index\":0,\"content_index\":0,\"delta\":\"Hello\"}\n\n",
+            "data: {\"type\":\"response.completed\",\"sequence_number\":2,\"response\":{",
+            "\"id\":\"resp-123\",\"created_at\":1677652288,\"output\":[{",
+            "\"type\":\"message\",\"role\":\"assistant\",\"content\":[{",
+            "\"type\":\"output_text\",\"text\":\"Hello\"}]}]}}\n\n",
+            "data: [DONE]\n\n"
+        );
+
+        let mock_client = MockHttpClient::new(StatusCode::OK, mock_stream);
+        let state = AppState::with_client(targets, mock_client);
+        let router = crate::strict::build_strict_router(state);
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/responses")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"model":"gpt-4o","input":"Hello","stream":true}"#,
+            ))
+            .unwrap();
+
+        let response = router.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body_str = String::from_utf8(body.to_vec()).unwrap();
+
+        assert!(body_str.contains("\"type\":\"response.created\""));
+        assert!(body_str.contains("\"type\":\"response.completed\""));
+        assert!(body_str.contains("\"model\":\"gpt-4o\""));
+        assert!(body_str.contains("\"id\":\"resp-123\""));
+        assert!(body_str.contains("\"status\":\"in_progress\""));
+        assert!(body_str.contains("\"status\":\"completed\""));
+        assert!(body_str.contains("\"tool_choice\":\"auto\""));
+        assert!(body_str.contains("\"delta\":\"Hello\""));
+        assert!(body_str.contains("[DONE]"));
+    }
+
+    #[tokio::test]
+    async fn test_strict_sanitize_responses_streaming_backfills_incomplete_details() {
+        let targets = Arc::new(DashMap::new());
+        targets.insert(
+            "gpt-4o".to_string(),
+            Target::builder()
+                .url("https://api.openai.com/v1/".parse().unwrap())
+                .onwards_key("sk-test".to_string())
+                .build()
+                .into_pool(),
+        );
+
+        let targets = Targets {
+            targets,
+            key_rate_limiters: Arc::new(DashMap::new()),
+            key_concurrency_limiters: Arc::new(DashMap::new()),
+            key_labels: Arc::new(DashMap::new()),
+            strict_mode: true,
+            http_pool_config: None,
+        };
+
+        let mock_stream = concat!(
+            "data: {\"type\":\"response.created\",\"sequence_number\":0,\"response\":{",
+            "\"id\":\"resp-123\",\"created_at\":1677652288,\"model\":\"provider-model\"}}\n\n",
+            "data: [DONE]\n\n"
+        );
+
+        let mock_client = MockHttpClient::new(StatusCode::OK, mock_stream);
+        let state = AppState::with_client(targets, mock_client);
+        let router = crate::strict::build_strict_router(state);
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/responses")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"model":"gpt-4o","input":"Hello","stream":true}"#,
+            ))
+            .unwrap();
+
+        let response = router.oneshot(request).await.unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body_str = String::from_utf8(body.to_vec()).unwrap();
+
+        assert!(body_str.contains("\"incomplete_details\":null"));
+    }
+
+    #[tokio::test]
+    async fn test_strict_sanitize_responses_streaming_reuses_fallback_id_across_snapshots() {
+        let targets = Arc::new(DashMap::new());
+        targets.insert(
+            "gpt-4o".to_string(),
+            Target::builder()
+                .url("https://api.openai.com/v1/".parse().unwrap())
+                .onwards_key("sk-test".to_string())
+                .build()
+                .into_pool(),
+        );
+
+        let targets = Targets {
+            targets,
+            key_rate_limiters: Arc::new(DashMap::new()),
+            key_concurrency_limiters: Arc::new(DashMap::new()),
+            key_labels: Arc::new(DashMap::new()),
+            strict_mode: true,
+            http_pool_config: None,
+        };
+
+        let mock_stream = concat!(
+            "data: {\"type\":\"response.created\",\"sequence_number\":0,\"response\":{",
+            "\"created_at\":1677652288,\"model\":\"provider-model\"}}\n\n",
+            "data: {\"type\":\"response.completed\",\"sequence_number\":1,\"response\":{",
+            "\"created_at\":1677652288,\"output\":[]}}\n\n",
+            "data: [DONE]\n\n"
+        );
+
+        let mock_client = MockHttpClient::new(StatusCode::OK, mock_stream);
+        let state = AppState::with_client(targets, mock_client);
+        let router = crate::strict::build_strict_router(state);
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/responses")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"model":"gpt-4o","input":"Hello","stream":true}"#,
+            ))
+            .unwrap();
+
+        let response = router.oneshot(request).await.unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body_str = String::from_utf8(body.to_vec()).unwrap();
+
+        let ids: Vec<String> = body_str
+            .lines()
+            .filter_map(|line| line.strip_prefix("data: "))
+            .filter(|data| *data != "[DONE]")
+            .map(|data| serde_json::from_str::<serde_json::Value>(data).unwrap())
+            .filter_map(|json| {
+                json.get("response")
+                    .and_then(|response| response.get("id"))
+                    .and_then(|id| id.as_str())
+                    .map(str::to_string)
+            })
+            .collect();
+
+        assert!(ids.len() >= 2);
+        assert!(ids.iter().all(|id| id == &ids[0]));
+    }
+
+    #[tokio::test]
+    async fn test_strict_sanitize_responses_streaming_forwards_error_object() {
+        let response = Response::builder()
+            .status(StatusCode::OK)
+            .header(header::CONTENT_TYPE, "text/event-stream")
+            .body(Body::from(
+                "data: {\"error\":{\"message\":\"Input too long\",\"type\":\"invalid_request_error\",\"code\":\"context_length_exceeded\"}}\n\n",
+            ))
+            .unwrap();
+
+        let result =
+            sanitize_streaming_responses_response(response, "test-model".to_string(), true).await;
+        assert_eq!(result.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(result.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body_str = String::from_utf8_lossy(&body);
+        assert!(body_str.contains("Input too long"));
+        assert!(body_str.contains("\"error\""));
     }
 
     #[tokio::test]
@@ -5263,6 +5946,76 @@ mod tests {
         assert!(!body_str.contains("internal-v2"));
     }
 
+    #[tokio::test]
+    async fn test_strict_sanitize_completions_backfills_missing_noncritical_fields() {
+        let mock_response = r#"{
+            "choices": [{"text": "Hello!", "finish_reason": "stop"}]
+        }"#;
+
+        let mock_client = MockHttpClient::new(StatusCode::OK, mock_response);
+        let state = AppState::with_client(
+            completions_test_targets("gpt-3.5-turbo-instruct"),
+            mock_client,
+        );
+        let router = crate::strict::build_strict_router(state);
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/completions")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"model":"gpt-3.5-turbo-instruct","prompt":"Say hello"}"#,
+            ))
+            .unwrap();
+
+        let response = router.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(json["model"], "gpt-3.5-turbo-instruct");
+        assert_eq!(json["object"], "text_completion");
+        let id = json["id"].as_str().expect("id should be a string");
+        assert!(id.starts_with("cmpl-"));
+        assert_eq!(json["choices"][0]["index"], 0);
+        assert_eq!(json["choices"][0]["text"], "Hello!");
+    }
+
+    #[tokio::test]
+    async fn test_strict_sanitize_completions_backfills_choice_indexes_from_position() {
+        let mock_response = r#"{
+            "choices": [{"text": "first"}, {"text": "second"}]
+        }"#;
+
+        let mock_client = MockHttpClient::new(StatusCode::OK, mock_response);
+        let state = AppState::with_client(
+            completions_test_targets("gpt-3.5-turbo-instruct"),
+            mock_client,
+        );
+        let router = crate::strict::build_strict_router(state);
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/completions")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"model":"gpt-3.5-turbo-instruct","prompt":"Say hello"}"#,
+            ))
+            .unwrap();
+
+        let response = router.oneshot(request).await.unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(json["choices"][0]["index"], 0);
+        assert_eq!(json["choices"][1]["index"], 1);
+    }
+
     /// Content-Length header is corrected after sanitization shrinks the body
     #[tokio::test]
     async fn test_completions_sanitization_updates_content_length_header() {
@@ -5451,6 +6204,123 @@ mod tests {
         // Client-requested model reflected back, not the internal provider version
         assert!(body_str.contains("\"model\":\"gpt-3.5-turbo-instruct\""));
         assert!(!body_str.contains("0914"));
+    }
+
+    #[tokio::test]
+    async fn test_strict_sanitize_completions_streaming_backfills_missing_noncritical_fields() {
+        let mock_client = MockHttpClient::new_streaming(
+            StatusCode::OK,
+            vec![
+                "data: {\"choices\":[{\"text\":\"Hello\"}]}\n\n".to_string(),
+                "data: [DONE]\n\n".to_string(),
+            ],
+        );
+        let state = AppState::with_client(
+            completions_test_targets("gpt-3.5-turbo-instruct"),
+            mock_client,
+        );
+        let router = crate::strict::build_strict_router(state);
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/completions")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"model":"gpt-3.5-turbo-instruct","prompt":"Hello","stream":true}"#,
+            ))
+            .unwrap();
+
+        let response = router.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body_str = String::from_utf8(body.to_vec()).unwrap();
+
+        assert!(body_str.contains("\"object\":\"text_completion\""));
+        assert!(body_str.contains("\"model\":\"gpt-3.5-turbo-instruct\""));
+        assert!(body_str.contains("\"index\":0"));
+        assert!(body_str.contains("\"text\":\"Hello\""));
+        assert!(body_str.contains("\"id\":\"cmpl-"));
+        assert!(body_str.contains("[DONE]"));
+    }
+
+    #[tokio::test]
+    async fn test_strict_sanitize_completions_streaming_backfills_chunk_indexes_from_position() {
+        let mock_client = MockHttpClient::new_streaming(
+            StatusCode::OK,
+            vec![
+                "data: {\"choices\":[{\"text\":\"first\"},{\"text\":\"second\"}]}\n\n".to_string(),
+                "data: [DONE]\n\n".to_string(),
+            ],
+        );
+        let state = AppState::with_client(
+            completions_test_targets("gpt-3.5-turbo-instruct"),
+            mock_client,
+        );
+        let router = crate::strict::build_strict_router(state);
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/completions")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"model":"gpt-3.5-turbo-instruct","prompt":"Hello","stream":true}"#,
+            ))
+            .unwrap();
+
+        let response = router.oneshot(request).await.unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body_str = String::from_utf8(body.to_vec()).unwrap();
+
+        assert!(body_str.contains("\"index\":0"));
+        assert!(body_str.contains("\"index\":1"));
+    }
+
+    #[tokio::test]
+    async fn test_strict_sanitize_completions_streaming_reuses_fallback_id_across_chunks() {
+        let mock_client = MockHttpClient::new_streaming(
+            StatusCode::OK,
+            vec![
+                "data: {\"choices\":[{\"text\":\"first\"}]}\n\n".to_string(),
+                "data: {\"choices\":[{\"text\":\"second\"}]}\n\n".to_string(),
+                "data: [DONE]\n\n".to_string(),
+            ],
+        );
+        let state = AppState::with_client(
+            completions_test_targets("gpt-3.5-turbo-instruct"),
+            mock_client,
+        );
+        let router = crate::strict::build_strict_router(state);
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/completions")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"model":"gpt-3.5-turbo-instruct","prompt":"Hello","stream":true}"#,
+            ))
+            .unwrap();
+
+        let response = router.oneshot(request).await.unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body_str = String::from_utf8(body.to_vec()).unwrap();
+
+        let ids: Vec<String> = body_str
+            .lines()
+            .filter_map(|line| line.strip_prefix("data: "))
+            .filter(|data| *data != "[DONE]")
+            .map(|data| serde_json::from_str::<serde_json::Value>(data).unwrap())
+            .filter_map(|json| json.get("id").and_then(|v| v.as_str()).map(str::to_string))
+            .collect();
+
+        assert!(ids.len() >= 2);
+        assert!(ids.iter().all(|id| id == &ids[0]));
     }
 
     #[tokio::test]

--- a/src/strict/schemas/chat_completions.rs
+++ b/src/strict/schemas/chat_completions.rs
@@ -4,14 +4,10 @@
 //! See: https://platform.openai.com/docs/api-reference/chat
 
 use serde::{Deserialize, Serialize};
-use serde_json::{Map, Value};
+use serde_json::Value;
 use uuid::Uuid;
 
-fn ensure_field(object: &mut Map<String, Value>, key: &str, default: impl FnOnce() -> Value) {
-    if !object.contains_key(key) {
-        object.insert(key.to_string(), default());
-    }
-}
+use super::utils::ensure_field;
 
 pub(crate) fn generated_chat_completion_id() -> String {
     format!("chatcmpl-{}", Uuid::new_v4())

--- a/src/strict/schemas/chat_completions.rs
+++ b/src/strict/schemas/chat_completions.rs
@@ -4,6 +4,124 @@
 //! See: https://platform.openai.com/docs/api-reference/chat
 
 use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use uuid::Uuid;
+
+fn ensure_field(object: &mut Map<String, Value>, key: &str, default: impl FnOnce() -> Value) {
+    if !object.contains_key(key) {
+        object.insert(key.to_string(), default());
+    }
+}
+
+pub(crate) fn generated_chat_completion_id() -> String {
+    format!("chatcmpl-{}", Uuid::new_v4())
+}
+
+fn normalize_chat_message_value(value: &mut Value) {
+    let Some(object) = value.as_object_mut() else {
+        return;
+    };
+
+    ensure_field(object, "role", || Value::String("assistant".to_string()));
+    ensure_field(object, "content", || Value::Null);
+}
+
+fn normalize_chat_choice_value(value: &mut Value, fallback_index: usize) {
+    let Some(object) = value.as_object_mut() else {
+        return;
+    };
+
+    ensure_field(object, "index", || Value::from(fallback_index));
+    ensure_field(object, "finish_reason", || Value::Null);
+    ensure_field(object, "logprobs", || Value::Null);
+
+    if let Some(message) = object.get_mut("message") {
+        normalize_chat_message_value(message);
+    }
+}
+
+fn normalize_chat_chunk_choice_value(value: &mut Value, fallback_index: usize) {
+    let Some(object) = value.as_object_mut() else {
+        return;
+    };
+
+    ensure_field(object, "index", || Value::from(fallback_index));
+    ensure_field(object, "finish_reason", || Value::Null);
+    ensure_field(object, "logprobs", || Value::Null);
+
+    if !object.contains_key("delta") {
+        object.insert("delta".to_string(), serde_json::json!({}));
+    }
+}
+
+/// Backfill omitted non-critical chat completion response fields during strict
+/// sanitization. This is intentionally kept out of serde defaults so we only
+/// relax third-party provider payloads, not every deserialize path.
+pub(crate) fn normalize_chat_completion_response_value(value: &mut Value, fallback_model: &str) {
+    let Some(object) = value.as_object_mut() else {
+        return;
+    };
+
+    // Only coerce payloads that already look like chat completion responses.
+    if !object.contains_key("choices") {
+        return;
+    }
+
+    ensure_field(object, "id", || {
+        Value::String(generated_chat_completion_id())
+    });
+    ensure_field(object, "object", || {
+        Value::String("chat.completion".to_string())
+    });
+    ensure_field(object, "created", || Value::from(0));
+    ensure_field(object, "model", || {
+        Value::String(fallback_model.to_string())
+    });
+    ensure_field(object, "usage", || Value::Null);
+    ensure_field(object, "system_fingerprint", || Value::Null);
+    ensure_field(object, "service_tier", || Value::Null);
+
+    if let Some(choices) = object.get_mut("choices").and_then(Value::as_array_mut) {
+        for (index, choice) in choices.iter_mut().enumerate() {
+            normalize_chat_choice_value(choice, index);
+        }
+    }
+}
+
+/// Backfill omitted non-critical chat completion chunk fields during strict
+/// sanitization. This keeps partial-but-usable streamed chunks from failing.
+pub(crate) fn normalize_chat_completion_chunk_value(
+    value: &mut Value,
+    fallback_model: &str,
+    fallback_id: &str,
+) {
+    let Some(object) = value.as_object_mut() else {
+        return;
+    };
+
+    // Only coerce payloads that already look like streamed chat chunks.
+    if !object.contains_key("choices") {
+        return;
+    }
+
+    ensure_field(object, "id", || Value::String(fallback_id.to_string()));
+    ensure_field(object, "object", || {
+        Value::String("chat.completion.chunk".to_string())
+    });
+    ensure_field(object, "created", || Value::from(0));
+    ensure_field(object, "model", || {
+        Value::String(fallback_model.to_string())
+    });
+    ensure_field(object, "usage", || Value::Null);
+    ensure_field(object, "system_fingerprint", || Value::Null);
+    ensure_field(object, "service_tier", || Value::Null);
+
+    if let Some(choices) = object.get_mut("choices").and_then(Value::as_array_mut) {
+        for (index, choice) in choices.iter_mut().enumerate() {
+            normalize_chat_chunk_choice_value(choice, index);
+        }
+    }
+}
 
 /// Request body for POST /v1/chat/completions
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/strict/schemas/completions.rs
+++ b/src/strict/schemas/completions.rs
@@ -8,8 +8,93 @@
 //! sanitized (unknown fields stripped, model field rewritten).
 
 use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use uuid::Uuid;
 
 use super::chat_completions::{StopSequence, Usage};
+
+fn ensure_field(object: &mut Map<String, Value>, key: &str, default: impl FnOnce() -> Value) {
+    if !object.contains_key(key) {
+        object.insert(key.to_string(), default());
+    }
+}
+
+pub(crate) fn generated_completion_id() -> String {
+    format!("cmpl-{}", Uuid::new_v4())
+}
+
+fn normalize_completion_choice_value(value: &mut Value, fallback_index: usize) {
+    let Some(object) = value.as_object_mut() else {
+        return;
+    };
+
+    ensure_field(object, "text", || Value::String(String::new()));
+    ensure_field(object, "index", || Value::from(fallback_index));
+    ensure_field(object, "logprobs", || Value::Null);
+    ensure_field(object, "finish_reason", || Value::Null);
+}
+
+/// Backfill omitted non-critical legacy completion response fields during
+/// strict sanitization. Kept out of serde defaults so only provider payloads
+/// are relaxed.
+pub(crate) fn normalize_completion_response_value(value: &mut Value, fallback_model: &str) {
+    let Some(object) = value.as_object_mut() else {
+        return;
+    };
+
+    if !object.contains_key("choices") {
+        return;
+    }
+
+    ensure_field(object, "id", || Value::String(generated_completion_id()));
+    ensure_field(object, "object", || {
+        Value::String("text_completion".to_string())
+    });
+    ensure_field(object, "created", || Value::from(0));
+    ensure_field(object, "model", || {
+        Value::String(fallback_model.to_string())
+    });
+    ensure_field(object, "usage", || Value::Null);
+    ensure_field(object, "system_fingerprint", || Value::Null);
+
+    if let Some(choices) = object.get_mut("choices").and_then(Value::as_array_mut) {
+        for (index, choice) in choices.iter_mut().enumerate() {
+            normalize_completion_choice_value(choice, index);
+        }
+    }
+}
+
+/// Backfill omitted non-critical legacy completion chunk fields during strict
+/// streaming sanitization.
+pub(crate) fn normalize_completion_chunk_value(
+    value: &mut Value,
+    fallback_model: &str,
+    fallback_id: &str,
+) {
+    let Some(object) = value.as_object_mut() else {
+        return;
+    };
+
+    if !object.contains_key("choices") {
+        return;
+    }
+
+    ensure_field(object, "id", || Value::String(fallback_id.to_string()));
+    ensure_field(object, "object", || {
+        Value::String("text_completion".to_string())
+    });
+    ensure_field(object, "created", || Value::from(0));
+    ensure_field(object, "model", || {
+        Value::String(fallback_model.to_string())
+    });
+    ensure_field(object, "usage", || Value::Null);
+
+    if let Some(choices) = object.get_mut("choices").and_then(Value::as_array_mut) {
+        for (index, choice) in choices.iter_mut().enumerate() {
+            normalize_completion_choice_value(choice, index);
+        }
+    }
+}
 
 /// Prompt input — matches the OpenAI spec `oneOf`: string | string[] | integer[] | integer[][]
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/strict/schemas/completions.rs
+++ b/src/strict/schemas/completions.rs
@@ -8,22 +8,27 @@
 //! sanitized (unknown fields stripped, model field rewritten).
 
 use serde::{Deserialize, Serialize};
-use serde_json::{Map, Value};
+use serde_json::Value;
 use uuid::Uuid;
 
 use super::chat_completions::{StopSequence, Usage};
-
-fn ensure_field(object: &mut Map<String, Value>, key: &str, default: impl FnOnce() -> Value) {
-    if !object.contains_key(key) {
-        object.insert(key.to_string(), default());
-    }
-}
+use super::utils::ensure_field;
 
 pub(crate) fn generated_completion_id() -> String {
     format!("cmpl-{}", Uuid::new_v4())
 }
 
-fn normalize_completion_choice_value(value: &mut Value, fallback_index: usize) {
+fn normalize_completion_response_choice_value(value: &mut Value, fallback_index: usize) {
+    let Some(object) = value.as_object_mut() else {
+        return;
+    };
+
+    ensure_field(object, "index", || Value::from(fallback_index));
+    ensure_field(object, "logprobs", || Value::Null);
+    ensure_field(object, "finish_reason", || Value::Null);
+}
+
+fn normalize_completion_chunk_choice_value(value: &mut Value, fallback_index: usize) {
     let Some(object) = value.as_object_mut() else {
         return;
     };
@@ -59,7 +64,7 @@ pub(crate) fn normalize_completion_response_value(value: &mut Value, fallback_mo
 
     if let Some(choices) = object.get_mut("choices").and_then(Value::as_array_mut) {
         for (index, choice) in choices.iter_mut().enumerate() {
-            normalize_completion_choice_value(choice, index);
+            normalize_completion_response_choice_value(choice, index);
         }
     }
 }
@@ -91,7 +96,7 @@ pub(crate) fn normalize_completion_chunk_value(
 
     if let Some(choices) = object.get_mut("choices").and_then(Value::as_array_mut) {
         for (index, choice) in choices.iter_mut().enumerate() {
-            normalize_completion_choice_value(choice, index);
+            normalize_completion_chunk_choice_value(choice, index);
         }
     }
 }

--- a/src/strict/schemas/mod.rs
+++ b/src/strict/schemas/mod.rs
@@ -8,3 +8,4 @@ pub mod chat_completions;
 pub mod completions;
 pub mod embeddings;
 pub mod responses;
+pub mod utils;

--- a/src/strict/schemas/responses.rs
+++ b/src/strict/schemas/responses.rs
@@ -4,6 +4,187 @@
 //! See: https://www.openresponses.org/specification
 
 use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use uuid::Uuid;
+
+fn ensure_field(object: &mut Map<String, Value>, key: &str, default: impl FnOnce() -> Value) {
+    if !object.contains_key(key) {
+        object.insert(key.to_string(), default());
+    }
+}
+
+pub(crate) fn generated_response_id() -> String {
+    format!("resp_{}", Uuid::new_v4())
+}
+
+fn response_status_for_event_type(event_type: &str) -> &'static str {
+    match event_type {
+        "response.created" | "response.in_progress" => "in_progress",
+        "response.completed" => "completed",
+        "response.failed" => "failed",
+        "response.incomplete" => "incomplete",
+        "response.cancelled" | "response.canceled" => "cancelled",
+        _ => "completed",
+    }
+}
+
+/// Fill in omitted non-critical fields so provider Responses payloads can still
+/// round-trip through the strict schema without discarding successful generations.
+///
+/// This is intentionally separate from serde defaults on `ResponsesResponse`.
+/// The struct is used as a strict schema in multiple contexts, and broad serde
+/// defaults would silently relax every deserialize path, including internal
+/// loads from the response store. We only want that leniency when sanitizing
+/// third-party provider payloads for client-facing strict mode.
+pub(crate) fn normalize_responses_response_value(value: &mut Value, fallback_model: &str) {
+    let Some(object) = value.as_object_mut() else {
+        return;
+    };
+
+    // Only coerce payloads that already look like Responses API success bodies.
+    if !object.contains_key("output") {
+        return;
+    }
+
+    ensure_field(object, "id", || Value::String(generated_response_id()));
+    ensure_field(object, "object", || Value::String("response".to_string()));
+    ensure_field(object, "created_at", || Value::from(0));
+    ensure_field(object, "completed_at", || Value::Null);
+    ensure_field(object, "status", || Value::String("completed".to_string()));
+    ensure_field(object, "incomplete_details", || Value::Null);
+    ensure_field(object, "model", || {
+        Value::String(fallback_model.to_string())
+    });
+    ensure_field(object, "previous_response_id", || Value::Null);
+    ensure_field(object, "instructions", || Value::Null);
+    ensure_field(object, "output", || Value::Array(Vec::new()));
+    ensure_field(object, "error", || Value::Null);
+    ensure_field(object, "tools", || Value::Array(Vec::new()));
+    ensure_field(object, "tool_choice", || Value::String("auto".to_string()));
+    ensure_field(object, "truncation", || {
+        Value::String("disabled".to_string())
+    });
+    ensure_field(object, "parallel_tool_calls", || Value::Bool(true));
+    ensure_field(object, "text", || {
+        serde_json::json!({
+            "format": {
+                "type": "text"
+            }
+        })
+    });
+    ensure_field(object, "top_p", || Value::from(1.0));
+    ensure_field(object, "presence_penalty", || Value::from(0.0));
+    ensure_field(object, "frequency_penalty", || Value::from(0.0));
+    ensure_field(object, "top_logprobs", || Value::from(0));
+    ensure_field(object, "temperature", || Value::from(1.0));
+    ensure_field(object, "reasoning", || Value::Null);
+    ensure_field(object, "usage", || Value::Null);
+    ensure_field(object, "max_output_tokens", || Value::Null);
+    ensure_field(object, "max_tool_calls", || Value::Null);
+    ensure_field(object, "store", || Value::Bool(false));
+    ensure_field(object, "background", || Value::Bool(false));
+    ensure_field(object, "service_tier", || {
+        Value::String("default".to_string())
+    });
+    ensure_field(object, "metadata", || Value::Null);
+    ensure_field(object, "safety_identifier", || Value::Null);
+    ensure_field(object, "prompt_cache_key", || Value::Null);
+}
+
+/// Normalize a Responses streaming event, backfilling a missing nested response
+/// snapshot with schema-valid defaults when the provider omits bookkeeping fields.
+///
+/// Streaming needs a dedicated normalizer because some defaults depend on the
+/// SSE event type itself, notably `status`.
+pub(crate) fn normalize_responses_streaming_event_value(
+    value: &mut Value,
+    fallback_model: &str,
+    fallback_response_id: &str,
+) {
+    let Some(object) = value.as_object_mut() else {
+        return;
+    };
+
+    let event_type = object
+        .get("type")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+
+    if let Some(response) = object.get_mut("response") {
+        let missing_status = response
+            .as_object()
+            .map(|response_object| !response_object.contains_key("status"))
+            .unwrap_or(false);
+
+        if let Some(response_object) = response.as_object_mut() {
+            ensure_field(response_object, "id", || {
+                Value::String(fallback_response_id.to_string())
+            });
+        }
+
+        normalize_responses_response_value(response, fallback_model);
+
+        if let Some(response_object) = response.as_object_mut() {
+            if missing_status {
+                response_object.insert(
+                    "status".to_string(),
+                    Value::String(response_status_for_event_type(&event_type).to_string()),
+                );
+            }
+
+            // Streaming snapshots like response.created may legitimately omit output.
+            ensure_field(response_object, "id", || {
+                Value::String(fallback_response_id.to_string())
+            });
+            ensure_field(response_object, "object", || {
+                Value::String("response".to_string())
+            });
+            ensure_field(response_object, "created_at", || Value::from(0));
+            ensure_field(response_object, "completed_at", || Value::Null);
+            ensure_field(response_object, "incomplete_details", || Value::Null);
+            ensure_field(response_object, "model", || {
+                Value::String(fallback_model.to_string())
+            });
+            ensure_field(response_object, "previous_response_id", || Value::Null);
+            ensure_field(response_object, "instructions", || Value::Null);
+            ensure_field(response_object, "output", || Value::Array(Vec::new()));
+            ensure_field(response_object, "error", || Value::Null);
+            ensure_field(response_object, "tools", || Value::Array(Vec::new()));
+            ensure_field(response_object, "tool_choice", || {
+                Value::String("auto".to_string())
+            });
+            ensure_field(response_object, "truncation", || {
+                Value::String("disabled".to_string())
+            });
+            ensure_field(response_object, "parallel_tool_calls", || Value::Bool(true));
+            ensure_field(response_object, "text", || {
+                serde_json::json!({
+                    "format": {
+                        "type": "text"
+                    }
+                })
+            });
+            ensure_field(response_object, "top_p", || Value::from(1.0));
+            ensure_field(response_object, "presence_penalty", || Value::from(0.0));
+            ensure_field(response_object, "frequency_penalty", || Value::from(0.0));
+            ensure_field(response_object, "top_logprobs", || Value::from(0));
+            ensure_field(response_object, "temperature", || Value::from(1.0));
+            ensure_field(response_object, "reasoning", || Value::Null);
+            ensure_field(response_object, "usage", || Value::Null);
+            ensure_field(response_object, "max_output_tokens", || Value::Null);
+            ensure_field(response_object, "max_tool_calls", || Value::Null);
+            ensure_field(response_object, "store", || Value::Bool(false));
+            ensure_field(response_object, "background", || Value::Bool(false));
+            ensure_field(response_object, "service_tier", || {
+                Value::String("default".to_string())
+            });
+            ensure_field(response_object, "metadata", || Value::Null);
+            ensure_field(response_object, "safety_identifier", || Value::Null);
+            ensure_field(response_object, "prompt_cache_key", || Value::Null);
+        }
+    }
+}
 
 /// Request body for POST /v1/responses
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/strict/schemas/responses.rs
+++ b/src/strict/schemas/responses.rs
@@ -24,25 +24,14 @@ fn response_status_for_event_type(event_type: &str) -> &'static str {
     }
 }
 
-/// Fill in omitted non-critical fields so provider Responses payloads can still
-/// round-trip through the strict schema without discarding successful generations.
-///
-/// This is intentionally separate from serde defaults on `ResponsesResponse`.
-/// The struct is used as a strict schema in multiple contexts, and broad serde
-/// defaults would silently relax every deserialize path, including internal
-/// loads from the response store. We only want that leniency when sanitizing
-/// third-party provider payloads for client-facing strict mode.
-pub(crate) fn normalize_responses_response_value(value: &mut Value, fallback_model: &str) {
-    let Some(object) = value.as_object_mut() else {
-        return;
-    };
-
-    // Only coerce payloads that already look like Responses API success bodies.
-    if !object.contains_key("output") {
-        return;
-    }
-
-    ensure_field(object, "id", || Value::String(generated_response_id()));
+fn backfill_responses_response_fields(
+    object: &mut serde_json::Map<String, Value>,
+    fallback_model: &str,
+    fallback_response_id: &str,
+) {
+    ensure_field(object, "id", || {
+        Value::String(fallback_response_id.to_string())
+    });
     ensure_field(object, "object", || Value::String("response".to_string()));
     ensure_field(object, "created_at", || Value::from(0));
     ensure_field(object, "completed_at", || Value::Null);
@@ -87,6 +76,28 @@ pub(crate) fn normalize_responses_response_value(value: &mut Value, fallback_mod
     ensure_field(object, "prompt_cache_key", || Value::Null);
 }
 
+/// Fill in omitted non-critical fields so provider Responses payloads can still
+/// round-trip through the strict schema without discarding successful generations.
+///
+/// This is intentionally separate from serde defaults on `ResponsesResponse`.
+/// The struct is used as a strict schema in multiple contexts, and broad serde
+/// defaults would silently relax every deserialize path, including internal
+/// loads from the response store. We only want that leniency when sanitizing
+/// third-party provider payloads for client-facing strict mode.
+pub(crate) fn normalize_responses_response_value(value: &mut Value, fallback_model: &str) {
+    let Some(object) = value.as_object_mut() else {
+        return;
+    };
+
+    // Only coerce payloads that already look like Responses API success bodies.
+    if !object.contains_key("output") {
+        return;
+    }
+
+    let fallback_response_id = generated_response_id();
+    backfill_responses_response_fields(object, fallback_model, &fallback_response_id);
+}
+
 /// Normalize a Responses streaming event, backfilling a missing nested response
 /// snapshot with schema-valid defaults when the provider omits bookkeeping fields.
 ///
@@ -114,14 +125,6 @@ pub(crate) fn normalize_responses_streaming_event_value(
             .unwrap_or(false);
 
         if let Some(response_object) = response.as_object_mut() {
-            ensure_field(response_object, "id", || {
-                Value::String(fallback_response_id.to_string())
-            });
-        }
-
-        normalize_responses_response_value(response, fallback_model);
-
-        if let Some(response_object) = response.as_object_mut() {
             if missing_status {
                 response_object.insert(
                     "status".to_string(),
@@ -130,54 +133,11 @@ pub(crate) fn normalize_responses_streaming_event_value(
             }
 
             // Streaming snapshots like response.created may legitimately omit output.
-            ensure_field(response_object, "id", || {
-                Value::String(fallback_response_id.to_string())
-            });
-            ensure_field(response_object, "object", || {
-                Value::String("response".to_string())
-            });
-            ensure_field(response_object, "created_at", || Value::from(0));
-            ensure_field(response_object, "completed_at", || Value::Null);
-            ensure_field(response_object, "incomplete_details", || Value::Null);
-            ensure_field(response_object, "model", || {
-                Value::String(fallback_model.to_string())
-            });
-            ensure_field(response_object, "previous_response_id", || Value::Null);
-            ensure_field(response_object, "instructions", || Value::Null);
-            ensure_field(response_object, "output", || Value::Array(Vec::new()));
-            ensure_field(response_object, "error", || Value::Null);
-            ensure_field(response_object, "tools", || Value::Array(Vec::new()));
-            ensure_field(response_object, "tool_choice", || {
-                Value::String("auto".to_string())
-            });
-            ensure_field(response_object, "truncation", || {
-                Value::String("disabled".to_string())
-            });
-            ensure_field(response_object, "parallel_tool_calls", || Value::Bool(true));
-            ensure_field(response_object, "text", || {
-                serde_json::json!({
-                    "format": {
-                        "type": "text"
-                    }
-                })
-            });
-            ensure_field(response_object, "top_p", || Value::from(1.0));
-            ensure_field(response_object, "presence_penalty", || Value::from(0.0));
-            ensure_field(response_object, "frequency_penalty", || Value::from(0.0));
-            ensure_field(response_object, "top_logprobs", || Value::from(0));
-            ensure_field(response_object, "temperature", || Value::from(1.0));
-            ensure_field(response_object, "reasoning", || Value::Null);
-            ensure_field(response_object, "usage", || Value::Null);
-            ensure_field(response_object, "max_output_tokens", || Value::Null);
-            ensure_field(response_object, "max_tool_calls", || Value::Null);
-            ensure_field(response_object, "store", || Value::Bool(false));
-            ensure_field(response_object, "background", || Value::Bool(false));
-            ensure_field(response_object, "service_tier", || {
-                Value::String("default".to_string())
-            });
-            ensure_field(response_object, "metadata", || Value::Null);
-            ensure_field(response_object, "safety_identifier", || Value::Null);
-            ensure_field(response_object, "prompt_cache_key", || Value::Null);
+            backfill_responses_response_fields(
+                response_object,
+                fallback_model,
+                fallback_response_id,
+            );
         }
     }
 }

--- a/src/strict/schemas/responses.rs
+++ b/src/strict/schemas/responses.rs
@@ -4,14 +4,10 @@
 //! See: https://www.openresponses.org/specification
 
 use serde::{Deserialize, Serialize};
-use serde_json::{Map, Value};
+use serde_json::Value;
 use uuid::Uuid;
 
-fn ensure_field(object: &mut Map<String, Value>, key: &str, default: impl FnOnce() -> Value) {
-    if !object.contains_key(key) {
-        object.insert(key.to_string(), default());
-    }
-}
+use super::utils::ensure_field;
 
 pub(crate) fn generated_response_id() -> String {
     format!("resp_{}", Uuid::new_v4())

--- a/src/strict/schemas/utils.rs
+++ b/src/strict/schemas/utils.rs
@@ -1,0 +1,17 @@
+use serde_json::{Map, Value};
+
+/// Insert a schema-valid placeholder only when the provider omitted a field.
+///
+/// This helper is used by strict-mode response sanitizers, not by the serde
+/// schema types themselves. Keeping these defaults out of the struct
+/// definitions avoids silently relaxing every deserialize path, including
+/// internal codepaths that should stay strict.
+pub(crate) fn ensure_field(
+    object: &mut Map<String, Value>,
+    key: &str,
+    default: impl FnOnce() -> Value,
+) {
+    if !object.contains_key(key) {
+        object.insert(key.to_string(), default());
+    }
+}


### PR DESCRIPTION
  ## Problem

  In strict mode, success responses are sanitized by deserializing provider payloads into typed OpenAI schemas and then re-serializing them.

  Some downstream providers return valid generations but omit schema-required, non-critical bookkeeping fields. In those cases, strict mode rejects the payload during sanitization even though the
  generation itself succeeded and already incurred downstream cost. That turns a usable provider response into a user-visible error.

  This failure mode is not limited to `/v1/responses`; the same pattern can affect strict chat completions and legacy completions as well.

  ## Solution

  Add sanitizer-layer normalization before typed deserialization for strict success responses.

  This backfills OpenAI-compatible placeholder defaults for omitted non-critical fields so successful generations can still round-trip through the strict schema. The actual generated output is
  preserved, and `usage` remains `null` when the provider did not send it.

  This now applies to:
  - non-streaming `/v1/chat/completions`
  - streaming `/v1/chat/completions`
  - non-streaming `/v1/completions`
  - streaming `/v1/completions`
  - non-streaming `/v1/responses`
  - streaming `/v1/responses` response snapshots

  ## Scope and Safety

  The normalization is intentionally scoped to the sanitizer layer rather than implemented as serde defaults on the schema structs.

  Those structs are used as strict schemas in multiple deserialize paths. Struct-level defaults would silently relax all of them, including internal loads and other strict-schema callsites. We only
  want this leniency when shaping third-party provider payloads into the public strict-mode response.

  Normalization is also gated so it only applies when the payload already resembles the expected endpoint response:
  - chat/completions payloads must already contain `choices`
  - completions payloads must already contain `choices`
  - non-streaming responses payloads must already contain `output`

  SSE error objects such as `{"error": ...}` are still handled through the existing streaming error path and are not coerced into successful responses.

  ## Why not serde defaults?

  This is intentionally not implemented with struct-level serde defaults.

  `ResponsesResponse`, `ChatCompletionResponse`, `ChatCompletionChunk`, `CompletionResponse`, and `CompletionChunk` are used as strict schema types. Adding serde defaults there would silently relax
  every deserialize path for those types, not just provider response sanitization.

  Streaming also needs event-aware defaults. In particular, some `/v1/responses` snapshot fields, especially `status`, depend on the SSE event type such as `response.created` vs `response.completed`,
  which is not a good fit for plain struct-level defaults.