### PR TITLE
feat: write id into chat completions

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -916,10 +916,11 @@ pub async fn target_message_handler<T: HttpClient>(
             }
         }
 
-        // Override the response `id` field for /responses requests when the
-        // caller supplied a response ID via the configured header.
+        // Override the response `id` field for /responses and /chat/completions
+        // requests when the caller supplied a response ID via the configured
+        // header. Both response bodies expose a top-level `id` we can rewrite.
         if let Some(ref header_name) = state.response_id_header
-            && path_and_query.contains("/responses")
+            && crate::response_id::path_supports_id_override(&path_and_query)
             && (200..300).contains(&status)
         {
             if let Some(override_id) =

--- a/src/response_id.rs
+++ b/src/response_id.rs
@@ -27,6 +27,19 @@ pub fn extract_override_id(headers: &HeaderMap, header_name: &str) -> Option<Str
         })
 }
 
+/// Returns true if response bodies at this path expose a top-level `id` field
+/// that the caller may want to override via the configured header.
+///
+/// Currently: `/v1/responses` (Open Responses API) and `/v1/chat/completions`
+/// (OpenAI-compatible chat completions). Query strings and trailing slashes
+/// are ignored; substring matches on other routes (e.g. `/responses-logs`)
+/// are rejected.
+pub fn path_supports_id_override(path_and_query: &str) -> bool {
+    let path = path_and_query.split('?').next().unwrap_or(path_and_query);
+    let path = path.trim_end_matches('/');
+    path.ends_with("/responses") || path.ends_with("/chat/completions")
+}
+
 /// Patch the `id` field in a JSON response body with the given override.
 ///
 /// Handles `Content-Encoding: gzip` and `Content-Encoding: br` transparently:
@@ -150,6 +163,49 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert("x-other", HeaderValue::from_static("abc"));
         assert_eq!(extract_override_id(&headers, "x-custom-id"), None);
+    }
+
+    // --- path_supports_id_override ---
+
+    #[test]
+    fn path_supports_id_override_responses() {
+        assert!(path_supports_id_override("/v1/responses"));
+        assert!(path_supports_id_override("/responses"));
+    }
+
+    #[test]
+    fn path_supports_id_override_chat_completions() {
+        assert!(path_supports_id_override("/v1/chat/completions"));
+        assert!(path_supports_id_override("/chat/completions"));
+    }
+
+    #[test]
+    fn path_supports_id_override_with_query_string() {
+        assert!(path_supports_id_override("/v1/chat/completions?stream=true"));
+        assert!(path_supports_id_override("/v1/responses?foo=bar"));
+    }
+
+    #[test]
+    fn path_supports_id_override_trailing_slash() {
+        assert!(path_supports_id_override("/v1/chat/completions/"));
+        assert!(path_supports_id_override("/v1/responses/"));
+    }
+
+    #[test]
+    fn path_supports_id_override_rejects_other_paths() {
+        assert!(!path_supports_id_override("/v1/embeddings"));
+        assert!(!path_supports_id_override("/v1/completions"));
+        assert!(!path_supports_id_override("/v1/models"));
+        assert!(!path_supports_id_override("/"));
+        assert!(!path_supports_id_override(""));
+    }
+
+    #[test]
+    fn path_supports_id_override_rejects_substring_lookalikes() {
+        // The old `.contains()` implementation matched these; `.ends_with()` should not.
+        assert!(!path_supports_id_override("/v1/responses-logs"));
+        assert!(!path_supports_id_override("/v1/chat/completions/history"));
+        assert!(!path_supports_id_override("/responses_v2"));
     }
 
     // --- patch_response_body_id ---


### PR DESCRIPTION
  Changes:                                                                                                                                                                                              
  - src/response_id.rs: new helper path_supports_id_override(path_and_query: &str) -> bool that returns true for /responses and /chat/completions, strips query string and trailing slash, uses .ends_with() instead of .contains() so
  /responses-logs and similar lookalikes no longer match.                                                                                                                                                                                      
  - src/handlers.rs: gate at line ~921 now calls the helper instead of inline .contains("/responses").
                                                                                                                                                                                                                                               
  Test coverage added in src/response_id.rs — 6 new unit tests for path_supports_id_override:                                                                                                                                                  
  - Matches /v1/responses and /responses                                                                                                                                                                                                       
  - Matches /v1/chat/completions and /chat/completions                                                                                                                                                                                         
  - Strips query strings (?stream=true)                                                                                                                                                                                                        
  - Strips trailing slash                                                                                                                                                                                                                      
  - Rejects other paths (/embeddings, /completions, /models, /, "")                                                                                                                                                                            
  - Rejects substring lookalikes (/responses-logs, /v1/chat/completions/history, /responses_v2) — regression guard for the .contains() → .ends_with() change
                                                                                                                                                                                                                                               
  Existing coverage retained:                                                                                                                                                                                                                  
  - extract_override_id — 4 tests (prefix handling, missing header)                                                                                                                                                                            
  - patch_response_body_id — 6 tests (gzip, brotli, non-JSON skip, content-length)                                                                                                                                                             
                                                                                  
  Strict-mode flow verified: strict::chat_completions_handler calls forward_request → target_message_handler (which runs the gate) → sanitize_chat_response, and ChatCompletionResponse.id: String is preserved through sanitization. The      
  streaming chat path uses SSE (text/event-stream), which patch_response_body_id correctly skips via its content-type check — streaming id rewriting is out of scope for this fix.                                                             
                                                                                                                                                                                                                                               
  All 342 onwards lib tests pass. cargo check --lib --tests clean.      