### PR TITLE
feat: multi-step feature flag use of fusillade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -986,6 +986,7 @@ dependencies = [
 [[package]]
 name = "fusillade"
 version = "17.0.0"
+source = "git+https://github.com/doublewordai/fusillade?branch=feat%2Fstreaming-event-callback#41d5c52130286877a8cbefb4c8ad2091c0e9835f"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -985,8 +985,8 @@ dependencies = [
 
 [[package]]
 name = "fusillade"
-version = "17.0.0"
-source = "git+https://github.com/doublewordai/fusillade?branch=feat%2Fstreaming-event-callback#41d5c52130286877a8cbefb4c8ad2091c0e9835f"
+version = "17.0.1"
+source = "git+https://github.com/doublewordai/fusillade?branch=main#975433e0812ee59d19609f54940e662bf25a64e5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,6 +178,28 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "axum"
@@ -278,6 +309,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,6 +325,18 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bon"
@@ -342,6 +391,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,6 +415,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -376,6 +433,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,6 +452,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -429,10 +498,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "cookie"
@@ -442,6 +545,16 @@ checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
  "time",
  "version_check",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -459,6 +572,39 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -479,10 +625,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "darling"
@@ -530,6 +695,7 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+ "serde",
 ]
 
 [[package]]
@@ -551,6 +717,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,6 +743,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,10 +766,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "email_address"
@@ -589,6 +793,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -616,6 +829,28 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -681,6 +916,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -723,12 +969,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "fusillade"
+version = "17.0.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "dashmap",
+ "eventsource-stream",
+ "futures",
+ "hostname",
+ "humantime",
+ "metrics",
+ "openai-reassembler",
+ "opentelemetry",
+ "parking_lot",
+ "rand 0.10.1",
+ "reqwest 0.13.3",
+ "scopeguard",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "sqlx-pool-router",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "tracing-opentelemetry",
+ "uuid",
 ]
 
 [[package]]
@@ -771,6 +1055,17 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
 ]
 
 [[package]]
@@ -826,6 +1121,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,6 +1166,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -888,7 +1194,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "quanta",
- "rand",
+ "rand 0.9.2",
  "smallvec",
  "spinning_top",
  "web-time",
@@ -925,6 +1231,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -940,6 +1248,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -950,6 +1267,50 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
+]
 
 [[package]]
 name = "http"
@@ -995,6 +1356,12 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
@@ -1070,9 +1437,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1292,6 +1661,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1326,6 +1754,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -1338,6 +1769,34 @@ name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "plain",
+ "redox_syscall 0.7.5",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1388,6 +1847,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1428,7 +1897,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "metrics",
  "quanta",
- "rand",
+ "rand 0.9.2",
  "rand_xoshiro",
  "sketches-ddsketch",
 ]
@@ -1561,6 +2030,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.6",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1613,6 +2098,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1654,6 +2140,7 @@ dependencies = [
  "dashmap",
  "eventsource-stream",
  "flate2",
+ "fusillade",
  "futures-util",
  "governor",
  "http-body-util",
@@ -1666,7 +2153,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
- "rand",
+ "rand 0.9.2",
  "rstest",
  "serde",
  "serde_json",
@@ -1761,7 +2248,7 @@ dependencies = [
  "bytes",
  "http",
  "opentelemetry",
- "reqwest",
+ "reqwest 0.12.28",
 ]
 
 [[package]]
@@ -1776,7 +2263,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest",
+ "reqwest 0.12.28",
  "thiserror",
 ]
 
@@ -1804,11 +2291,17 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand",
+ "rand 0.9.2",
  "thiserror",
  "tokio",
  "tokio-stream",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -1828,9 +2321,18 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -1872,10 +2374,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "portable-atomic"
@@ -2009,10 +2538,11 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2061,12 +2591,44 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2076,7 +2638,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2089,12 +2660,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_xoshiro"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2111,6 +2688,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -2191,6 +2777,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
 name = "reserve-port"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2211,6 +2840,26 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2253,7 +2902,7 @@ dependencies = [
  "futures-util",
  "http",
  "mime",
- "rand",
+ "rand 0.9.2",
  "thiserror",
 ]
 
@@ -2291,6 +2940,7 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -2322,11 +2972,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2375,7 +3053,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2464,6 +3142,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2479,10 +3179,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "sketches-ddsketch"
@@ -2501,6 +3237,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -2513,6 +3252,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spinning_top"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2522,10 +3270,238 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64",
+ "bytes",
+ "chrono",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink",
+ "indexmap",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "uuid",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags 2.11.0",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc",
+ "digest",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.6",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-pool-router"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e9b977ec33ab01a8c211001e3e72b5d5a4ef95ef0c16cbf661de859c2c66ba3"
+dependencies = [
+ "sqlx",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags 2.11.0",
+ "byteorder",
+ "chrono",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "chrono",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -2568,6 +3544,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2677,7 +3674,9 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -2938,6 +3937,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "typetag"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2962,10 +3967,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-xid"
@@ -3012,6 +4038,7 @@ checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -3075,6 +4102,12 @@ checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -3158,6 +4191,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3187,6 +4233,43 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
 ]
 
 [[package]]
@@ -3262,6 +4345,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3277,6 +4371,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -3304,6 +4407,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -3341,6 +4459,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -3353,6 +4477,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -3362,6 +4492,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3389,6 +4525,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -3398,6 +4540,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3413,6 +4561,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -3422,6 +4576,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,18 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,9 +49,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -76,15 +64,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -203,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
@@ -316,15 +304,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
 ]
@@ -340,9 +322,9 @@ dependencies = [
 
 [[package]]
 name = "bon"
-version = "3.9.0"
+version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d13a61f2963b88eef9c1be03df65d42f6996dfeac1054870d950fcf66686f83"
+checksum = "f47dbe92550676ee653353c310dfb9cf6ba17ee70396e1f7cf0a2020ad49b2fe"
 dependencies = [
  "bon-macros",
  "rustversion",
@@ -350,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "bon-macros"
-version = "3.9.0"
+version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d314cc62af2b6b0c65780555abb4d02a03dd3b799cd42419044f0c38d99738c0"
+checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
  "darling",
  "ident_case",
@@ -410,9 +392,9 @@ checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -459,9 +441,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -469,9 +451,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -481,9 +463,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -493,9 +475,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
@@ -508,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -685,9 +667,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -865,6 +847,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "evmap"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8874945f036109c72242964c1174cf99434e30cfa45bf45fedc983f50046f8"
+dependencies = [
+ "hashbag",
+ "left-right",
+ "smallvec",
+]
+
+[[package]]
 name = "expect-json"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -895,9 +888,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -985,8 +978,9 @@ dependencies = [
 
 [[package]]
 name = "fusillade"
-version = "17.0.1"
-source = "git+https://github.com/doublewordai/fusillade?branch=main#975433e0812ee59d19609f54940e662bf25a64e5"
+version = "17.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba270cfbceca4ece0a85b337a8d8599e16548a104077097631a1ce81bb6a636"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1122,6 +1116,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1195,7 +1204,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "quanta",
- "rand 0.9.2",
+ "rand 0.9.4",
  "smallvec",
  "spinning_top",
  "web-time",
@@ -1203,9 +1212,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1219,6 +1228,12 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbag"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7040a10f52cba493ddb09926e15d10a9d8a28043708a405931fe4c6f19fac064"
 
 [[package]]
 name = "hashbrown"
@@ -1247,6 +1262,12 @@ dependencies = [
  "equivalent",
  "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -1366,9 +1387,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1381,7 +1402,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1389,16 +1409,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
  "rustls-native-certs",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1471,12 +1490,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1484,9 +1504,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1497,9 +1517,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1511,15 +1531,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1531,15 +1551,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1575,9 +1595,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1585,12 +1605,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1601,7 +1621,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "inotify-sys",
  "libc",
 ]
@@ -1617,9 +1637,9 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "009ae045c87e7082cb72dab0ccd01ae075dd00141ddc108f43a0ea150a9e7227"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
  "rustversion",
 ]
@@ -1629,16 +1649,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1657,9 +1667,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
@@ -1722,10 +1732,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1742,11 +1754,11 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.0.4"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "libc",
 ]
 
@@ -1766,10 +1778,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
-name = "libc"
-version = "0.2.183"
+name = "left-right"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "0f0c21e4c8ff95f487fb34e6f9182875f42c84cef966d29216bf115d9bba835a"
+dependencies = [
+ "crossbeam-utils",
+ "loom",
+ "slab",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -1783,7 +1806,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "libc",
  "plain",
  "redox_syscall 0.7.5",
@@ -1807,9 +1830,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -1825,6 +1848,19 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "lru-slab"
@@ -1865,21 +1901,22 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "metrics"
-version = "0.24.3"
+version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
 dependencies = [
- "ahash",
  "portable-atomic",
+ "rapidhash",
 ]
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.18.1"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3589659543c04c7dc5526ec858591015b87cd8746583b51b48ef4353f99dbcda"
+checksum = "1db0d8f1fc9e62caebd0319e11eaec5822b0186c171568f0480b46a0137f9108"
 dependencies = [
  "base64",
+ "evmap",
  "indexmap",
  "metrics",
  "metrics-util",
@@ -1889,17 +1926,18 @@ dependencies = [
 
 [[package]]
 name = "metrics-util"
-version = "0.20.1"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdfb1365fea27e6dd9dc1dbc19f570198bc86914533ad639dae939635f096be4"
+checksum = "96f8722f8562635f92f8ed992f26df0532266eb03d5202607c20c0d7e9745e13"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.16.1",
  "metrics",
  "quanta",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_xoshiro",
+ "rapidhash",
  "sketches-ddsketch",
 ]
 
@@ -1927,9 +1965,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "log",
@@ -1976,7 +2014,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -1994,7 +2032,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -2057,9 +2095,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -2114,9 +2152,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -2154,7 +2192,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rstest",
  "serde",
  "serde_json",
@@ -2183,15 +2221,14 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -2215,9 +2252,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
@@ -2254,9 +2291,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
 dependencies = [
  "http",
  "opentelemetry",
@@ -2292,7 +2329,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.9.4",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -2344,18 +2381,18 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2367,12 +2404,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs1"
@@ -2397,9 +2428,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -2415,9 +2446,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -2543,7 +2574,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2603,9 +2634,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2676,12 +2707,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rapidhash"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "raw-cpuid"
 version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -2690,7 +2730,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -2699,7 +2739,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -2903,15 +2943,15 @@ dependencies = [
  "futures-util",
  "http",
  "mime",
- "rand 0.9.2",
+ "rand 0.9.4",
  "thiserror",
 ]
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -2928,7 +2968,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2937,9 +2977,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -2964,9 +3004,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3001,9 +3041,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3042,6 +3082,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3053,7 +3099,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -3072,9 +3118,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -3377,7 +3423,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64",
- "bitflags 2.11.0",
+ "bitflags",
  "byteorder",
  "bytes",
  "chrono",
@@ -3430,7 +3476,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64",
- "bitflags 2.11.0",
+ "bitflags",
  "byteorder",
  "chrono",
  "crc",
@@ -3553,7 +3599,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -3570,9 +3616,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom 0.4.2",
@@ -3643,9 +3689,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3653,9 +3699,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3668,9 +3714,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -3685,9 +3731,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3741,18 +3787,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.4+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -3762,18 +3808,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "tonic"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "base64",
@@ -3792,9 +3838,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
  "prost",
@@ -3819,20 +3865,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -3909,9 +3955,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -4033,9 +4079,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -4088,11 +4134,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -4101,7 +4147,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -4112,9 +4158,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4125,23 +4171,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4149,9 +4191,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4162,9 +4204,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -4210,7 +4252,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -4218,9 +4260,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4598,9 +4640,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -4636,6 +4678,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -4686,7 +4734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags",
  "indexmap",
  "log",
  "serde",
@@ -4718,9 +4766,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yansi"
@@ -4730,9 +4778,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -4741,9 +4789,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4753,18 +4801,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4773,18 +4821,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4800,9 +4848,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -4811,9 +4859,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4822,9 +4870,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,16 @@ documentation = "https://docs.rs/onwards"
 keywords = ["llm", "proxy", "ai", "openai", "anthropic"]
 categories = ["web-programming", "api-bindings"]
 
+[features]
+default = []
+# Enables the multi-step Open Responses orchestration loop, the
+# `MultiStepStore` trait, and the `streaming` event-sink machinery.
+# Pulls in `fusillade` for `HttpClient` / `RequestData` / `StreamEvent`
+# so per-step HTTP fires get fusillade's row-id header stamping +
+# reassembly machinery for free. Off by default — the simple
+# `/ai/v1/*` proxy path doesn't need any of it.
+multi-step = ["dep:fusillade"]
+
 [dependencies]
 anyhow = { version = "1.0.98", features = ["backtrace"] }
 async-stream = "0.3"
@@ -60,6 +70,7 @@ metrics = "0.24"
 governor = "0.10.1"
 rand = "0.9"
 uuid = { version = "1", features = ["v4"] }
+fusillade = { path = "../fusillade", optional = true }
 
 [dev-dependencies]
 axum-test = "18.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,12 @@ metrics = "0.24"
 governor = "0.10.1"
 rand = "0.9"
 uuid = { version = "1", features = ["v4"] }
-fusillade = { path = "../fusillade", optional = true }
+# Tracking the fusillade `feat/streaming-event-callback` branch until
+# the new `StreamEvent` / `StreamEventCallback` types ship in a tagged
+# release. Switch this to `version = "17.X"` once fusillade publishes
+# the matching version on crates.io and update the changelog entry to
+# match.
+fusillade = { git = "https://github.com/doublewordai/fusillade", branch = "feat/streaming-event-callback", optional = true }
 
 [dev-dependencies]
 axum-test = "18.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,11 +70,7 @@ metrics = "0.24"
 governor = "0.10.1"
 rand = "0.9"
 uuid = { version = "1", features = ["v4"] }
-# Tracking fusillade `main` until the streaming-event-callback work
-# (already merged) ships in a tagged release. Switch this to
-# `version = "17.X"` once fusillade publishes the matching version
-# on crates.io.
-fusillade = { git = "https://github.com/doublewordai/fusillade", branch = "main", optional = true }
+fusillade = { version = "17.0.2", optional = true }
 
 [dev-dependencies]
 axum-test = "18.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,12 +70,11 @@ metrics = "0.24"
 governor = "0.10.1"
 rand = "0.9"
 uuid = { version = "1", features = ["v4"] }
-# Tracking the fusillade `feat/streaming-event-callback` branch until
-# the new `StreamEvent` / `StreamEventCallback` types ship in a tagged
-# release. Switch this to `version = "17.X"` once fusillade publishes
-# the matching version on crates.io and update the changelog entry to
-# match.
-fusillade = { git = "https://github.com/doublewordai/fusillade", branch = "feat/streaming-event-callback", optional = true }
+# Tracking fusillade `main` until the streaming-event-callback work
+# (already merged) ships in a tagged release. Switch this to
+# `version = "17.X"` once fusillade publishes the matching version
+# on crates.io.
+fusillade = { git = "https://github.com/doublewordai/fusillade", branch = "main", optional = true }
 
 [dev-dependencies]
 axum-test = "18.0.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,11 +52,13 @@ pub mod handlers;
 pub mod load_balancer;
 pub mod models;
 pub mod response_id;
+#[cfg(feature = "multi-step")]
 pub mod response_loop;
 pub mod response_sanitizer;
 pub mod sse;
-pub mod strict;
+#[cfg(feature = "multi-step")]
 pub mod streaming;
+pub mod strict;
 pub mod target;
 pub mod telemetry;
 pub mod traits;
@@ -64,12 +66,18 @@ pub mod traits;
 use client::{HttpClient, HyperClient};
 use handlers::{models as models_handler, target_message_handler};
 use models::ExtractedModel;
+#[cfg(feature = "multi-step")]
 pub use response_loop::{LoopConfig, LoopError, UpstreamTarget, run_response_loop};
+#[cfg(feature = "multi-step")]
 pub use streaming::{EventSink, EventSinkError, LoopEvent, LoopEventKind};
+#[cfg(feature = "multi-step")]
 pub use traits::{
-    ChainStep, ExecutorError, MultiStepStore, NextAction, NoOpResponseStore, NoOpToolExecutor,
-    RecordedStep, RequestContext, ResponseStore, StepDescriptor, StepKind, StepState, StoreError,
-    ToolError, ToolExecutor, ToolKind, ToolSchema,
+    ChainStep, ExecutorError, MultiStepStore, NextAction, RecordedStep, StepDescriptor, StepKind,
+    StepState,
+};
+pub use traits::{
+    NoOpResponseStore, NoOpToolExecutor, RequestContext, ResponseStore, StoreError, ToolError,
+    ToolExecutor, ToolKind, ToolSchema,
 };
 
 /// Type alias for body transformation function

--- a/src/response_loop.rs
+++ b/src/response_loop.rs
@@ -88,8 +88,11 @@ pub struct UpstreamTarget {
     /// Path component matched against fusillade's `streamable_endpoints`
     /// list (e.g. `/v1/chat/completions`).
     pub path: String,
-    /// Bearer token for the upstream call, if any. `None` skips the
-    /// `Authorization` header.
+    /// Bearer token for the upstream call. `None` and `Some("")` are
+    /// equivalent: both result in no `Authorization` header on the
+    /// outgoing request (fusillade's `ReqwestHttpClient` only stamps
+    /// the header when the api_key is non-empty), so callers can use
+    /// whichever shape matches their config-loading code.
     pub api_key: Option<String>,
 }
 
@@ -576,12 +579,18 @@ async fn fire_model_call<H: FusilladeHttpClient + 'static>(
     let response = if stream_mode {
         // Bridge: the callback is synchronous (fusillade's contract — see
         // its StreamEventCallback docstring) but the sink is async. Push
-        // LoopEvents through an unbounded mpsc; a drain future running
+        // LoopEvents through a bounded mpsc; a drain future running
         // concurrently with the model fire awaits them and forwards.
         // When fusillade's `execute_with_event_callback` returns, the
         // last Arc<dyn StreamEventCallback> drops, the Sender drops, the
         // channel closes, and the drain future completes naturally.
-        let (event_tx, event_rx) = mpsc::unbounded_channel::<crate::streaming::LoopEvent>();
+        //
+        // Bounded capacity caps memory if the downstream sink stalls
+        // (slow / disconnected client). Overflow drops the newest event
+        // — `try_emit` already swallows sink-emit failures, so the
+        // overall semantic is "best-effort live tail" either way.
+        let (event_tx, event_rx) =
+            mpsc::channel::<crate::streaming::LoopEvent>(SINK_BRIDGE_CAPACITY);
         let callback: Arc<dyn StreamEventCallback> = Arc::new(SinkChannelCallback {
             tx: event_tx,
             step_sequence,
@@ -621,27 +630,36 @@ async fn fire_model_call<H: FusilladeHttpClient + 'static>(
     })
 }
 
+/// Capacity of the bridge channel between fusillade's per-chunk
+/// callback and the async event sink. Picked to hold a comfortable
+/// burst of token deltas (an LLM emitting at hundreds-of-tokens/s
+/// while the client is briefly stalled) without unbounded growth.
+/// Overflow drops the newest event — fusillade's reassembler still
+/// produces the correct final body, so only the live tail is affected.
+const SINK_BRIDGE_CAPACITY: usize = 1024;
+
 /// Synchronous [`StreamEventCallback`] that bridges fusillade's
 /// chunk-by-chunk SSE callbacks into onwards' async [`EventSink`]
-/// vocabulary via an unbounded mpsc channel. The drain side of the
+/// vocabulary via a bounded mpsc channel. The drain side of the
 /// channel runs concurrently with the model fire (see
 /// [`fire_model_call`]) and forwards each event to the sink.
 ///
-/// Unbounded send is fine here: token chunks are small and the consumer
-/// (an axum SSE response) processes them as fast as they arrive over
-/// HTTP chunked transfer. The actual upstream-throttling backpressure
-/// surface is the model itself, not the channel.
+/// Uses `try_send` so the callback stays synchronous — overflow
+/// (drain side slow / client stalled) drops the event instead of
+/// blocking the upstream-read loop and tripping `body_timeout`.
 struct SinkChannelCallback {
-    tx: mpsc::UnboundedSender<crate::streaming::LoopEvent>,
+    tx: mpsc::Sender<crate::streaming::LoopEvent>,
     step_sequence: i64,
 }
 
 impl StreamEventCallback for SinkChannelCallback {
-    fn on_event(&self, event: &StreamEvent) {
+    fn on_event(&self, event: &StreamEvent<'_>) {
         for loop_event in delta_loop_events(event, self.step_sequence) {
-            // Drop events if the receiver was dropped — same best-effort
-            // semantic as `streaming::try_emit`'s closed-sink path.
-            let _ = self.tx.send(loop_event);
+            // Drop on closed/full channel — same best-effort semantic
+            // as `streaming::try_emit`'s closed-sink path. A full
+            // channel here means the SSE consumer is too slow; the
+            // reassembled final body is unaffected, only the live tail.
+            let _ = self.tx.try_send(loop_event);
         }
     }
 }

--- a/src/response_loop.rs
+++ b/src/response_loop.rs
@@ -14,9 +14,15 @@
 //!   their [`ToolKind`]; [`ToolExecutor::execute`] runs `Http`-kind
 //!   tools. `Agent`-kind tools cause the loop to recurse into a sub-loop
 //!   instead of calling `execute`.
-//! - **Model calls** — fired directly by the loop using the supplied
-//!   `reqwest::Client` against the configured [`UpstreamTarget`]. No
-//!   trait abstraction.
+//! - **Model calls** — fired via [`fusillade::HttpClient`] against the
+//!   configured [`UpstreamTarget`]. Going through fusillade gets us the
+//!   `X-Fusillade-Request-Id` header stamping (using the
+//!   `RecordedStep.sub_request_id` the store handed back) for free, so
+//!   the `http_analytics` row produced by outlet middleware lines up
+//!   with the right row in `fusillade.requests`. Streaming responses
+//!   plug an [`fusillade::StreamEventCallback`] into the existing
+//!   chunk-read loop so live token deltas reach the [`EventSink`]
+//!   without losing fusillade's reassembly machinery.
 //!
 //! This means dwctl's existing `HttpToolExecutor` (which already
 //! implements `ToolExecutor`) plugs straight in — no wrapping, no
@@ -28,15 +34,18 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use axum::body::Body;
-use axum::http::header::AUTHORIZATION;
+use fusillade::{
+    HttpClient as FusilladeHttpClient, RequestData, RequestId, StreamEvent, StreamEventCallback,
+    TemplateId,
+};
 use serde_json::Value;
+use tokio::sync::mpsc;
+use uuid::Uuid;
 
-use crate::client::HttpClient;
 use crate::streaming::EventSink;
 use crate::traits::{
-    ChainStep, ExecutorError, MultiStepStore, NextAction, RequestContext, StepDescriptor,
-    StepKind, StoreError, ToolError, ToolExecutor, ToolKind,
+    ChainStep, ExecutorError, MultiStepStore, NextAction, RecordedStep, RequestContext,
+    StepDescriptor, StepKind, StoreError, ToolError, ToolExecutor, ToolKind,
 };
 
 /// Type alias for the recursive sub-loop call. Required because async fns
@@ -65,12 +74,22 @@ impl Default for LoopConfig {
 
 /// Where the loop should send model_call HTTP requests.
 ///
-/// The integration test passes a wiremock URL; production wiring will
-/// pass a target resolved through onwards' load balancer (this is the
-/// follow-up coupling for COR-349).
+/// Split into `endpoint` (base URL) + `path` rather than a single
+/// concatenated URL because fusillade's `HttpClient` classifies
+/// streaming-vs-buffered behavior off the `path` component of the
+/// `RequestData` it receives — passing the full URL in `endpoint` with
+/// `path = ""` defeats streamable-endpoint matching and forces every
+/// model fire down the non-streaming path.
 #[derive(Debug, Clone)]
 pub struct UpstreamTarget {
-    pub url: String,
+    /// Base URL — protocol + host + any prefix path that's not
+    /// streamable-dispatched (e.g. `http://127.0.0.1:3001/ai`).
+    pub endpoint: String,
+    /// Path component matched against fusillade's `streamable_endpoints`
+    /// list (e.g. `/v1/chat/completions`).
+    pub path: String,
+    /// Bearer token for the upstream call, if any. `None` skips the
+    /// `Authorization` header.
     pub api_key: Option<String>,
 }
 
@@ -133,12 +152,12 @@ impl From<ExecutorError> for LoopError {
 /// `tool_ctx` is the `RequestContext` passed to `ToolExecutor::tools`
 /// and `::execute` — carries the per-request resolved tool set for
 /// dwctl's middleware-driven model.
-pub fn run_response_loop<'a, S, T>(
+pub fn run_response_loop<'a, S, T, H>(
     store: &'a S,
     tool_executor: &'a T,
     tool_ctx: &'a RequestContext,
     model_target: &'a UpstreamTarget,
-    http_client: Arc<dyn HttpClient + Send + Sync>,
+    http_client: Arc<H>,
     event_sink: Option<&'a (dyn EventSink + 'a)>,
     request_id: &'a str,
     scope_parent: Option<&'a str>,
@@ -148,6 +167,7 @@ pub fn run_response_loop<'a, S, T>(
 where
     S: MultiStepStore + ?Sized,
     T: ToolExecutor + ?Sized,
+    H: FusilladeHttpClient + 'static,
 {
     Box::pin(async move {
         if depth > config.max_response_step_depth {
@@ -175,7 +195,8 @@ where
 
         // Once-per-response `created` event for the user-visible loop
         // (top-level only; sub-agents don't emit their own created).
-        if depth == 0 && scope_parent.is_none()
+        if depth == 0
+            && scope_parent.is_none()
             && let Some(sink) = event_sink
         {
             crate::streaming::try_emit(
@@ -242,9 +263,13 @@ where
                     // though execution is concurrent below. record_step
                     // allocates the sequence atomically — N siblings = N
                     // queries (no separate sequence-allocation
-                    // round-trip).
-                    let mut step_ids: Vec<String> = Vec::with_capacity(descriptors.len());
-                    let mut step_sequences: Vec<i64> = Vec::with_capacity(descriptors.len());
+                    // round-trip). RecordedStep also carries the
+                    // sub-request fusillade row id (Some for model_call,
+                    // None for tool_call) so execute_step can stamp it
+                    // as `X-Fusillade-Request-Id` on the outgoing HTTP
+                    // fire, lining up with the analytics row.
+                    let mut recorded_steps: Vec<RecordedStep> =
+                        Vec::with_capacity(descriptors.len());
                     let mut current_prev: Option<String> = prev_step.clone();
                     for descriptor in &descriptors {
                         let recorded = store
@@ -256,19 +281,15 @@ where
                             )
                             .await?;
                         current_prev = Some(recorded.id.clone());
-                        step_ids.push(recorded.id);
-                        step_sequences.push(recorded.sequence);
+                        recorded_steps.push(recorded);
                     }
 
                     // Execute siblings concurrently. Per-step failures
                     // are persisted via fail_step and swallowed; storage
                     // failures propagate. Sub-agent recursion happens
                     // inside execute_step.
-                    let futures = descriptors
-                        .iter()
-                        .zip(step_ids.iter())
-                        .zip(step_sequences.iter().copied())
-                        .map(|((descriptor, step_id), step_sequence)| {
+                    let futures = descriptors.iter().zip(recorded_steps.iter()).map(
+                        |(descriptor, recorded)| {
                             execute_step(
                                 store,
                                 tool_executor,
@@ -278,8 +299,9 @@ where
                                 event_sink,
                                 &kinds,
                                 request_id,
-                                step_id,
-                                step_sequence,
+                                &recorded.id,
+                                recorded.sequence,
+                                recorded.sub_request_id,
                                 descriptor,
                                 config,
                                 depth,
@@ -293,7 +315,7 @@ where
                         outcome?;
                     }
 
-                    prev_step = step_ids.last().cloned();
+                    prev_step = recorded_steps.last().map(|r| r.id.clone());
                 }
             }
         }
@@ -301,17 +323,18 @@ where
 }
 
 #[allow(clippy::too_many_arguments)]
-fn execute_step<'a, S, T>(
+fn execute_step<'a, S, T, H>(
     store: &'a S,
     tool_executor: &'a T,
     tool_ctx: &'a RequestContext,
     model_target: &'a UpstreamTarget,
-    http_client: Arc<dyn HttpClient + Send + Sync>,
+    http_client: Arc<H>,
     event_sink: Option<&'a (dyn EventSink + 'a)>,
     kinds: &'a HashMap<String, ToolKind>,
     request_id: &'a str,
     step_id: &'a str,
     step_sequence: i64,
+    sub_request_id: Option<RequestId>,
     descriptor: &'a StepDescriptor,
     config: LoopConfig,
     depth: u32,
@@ -319,15 +342,28 @@ fn execute_step<'a, S, T>(
 where
     S: MultiStepStore + ?Sized,
     T: ToolExecutor + ?Sized,
+    H: FusilladeHttpClient + 'static,
 {
     Box::pin(async move {
         store.mark_step_processing(step_id).await?;
 
         let outcome: Result<Value, LoopError> = match descriptor.kind {
             StepKind::ModelCall => {
+                // The store contract (RecordedStep) guarantees model_call
+                // steps carry a sub_request_id — that row anchors the
+                // analytics linkage. Surface a clean error rather than
+                // panicking if a store implementation violates it.
+                let sub_request_id = sub_request_id.ok_or_else(|| {
+                    LoopError::Executor(ExecutorError::ExecutionError(
+                        "model_call step has no sub_request_id; \
+                         MultiStepStore::record_step must populate it for ModelCall"
+                            .into(),
+                    ))
+                })?;
                 fire_model_call(
                     &*http_client,
                     model_target,
+                    sub_request_id,
                     &descriptor.request_payload,
                     event_sink,
                     step_sequence,
@@ -484,173 +520,167 @@ where
     }
 }
 
-async fn fire_model_call(
-    http_client: &(dyn HttpClient + Send + Sync),
+async fn fire_model_call<H: FusilladeHttpClient + 'static>(
+    http_client: &H,
     target: &UpstreamTarget,
+    sub_request_id: RequestId,
     request_payload: &Value,
     sink: Option<&dyn EventSink>,
     step_sequence: i64,
 ) -> Result<Value, LoopError> {
     // The user's `stream` flag propagates through the parent request →
-    // transition function → request_payload here. When true, we open a
-    // streaming HTTP request, parse SSE events, forward token deltas
-    // to the sink, and reassemble the final body via the upstream's
-    // own done-marker. When false, we POST and parse a single JSON
-    // body, ignoring the sink even if one is supplied (no SSE events
-    // to forward).
+    // transition function → request_payload here. When true, fusillade's
+    // streaming HTTP path parses SSE events, our callback forwards token
+    // deltas to the sink as each event arrives, and the reassembler
+    // hands us the final body. When false, we POST and parse a single
+    // JSON body, ignoring the sink even if one is supplied.
     let stream_mode = request_payload
         .get("stream")
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
 
-    let body_bytes = serde_json::to_vec(request_payload).map_err(|e| {
+    let body = serde_json::to_string(request_payload).map_err(|e| {
         LoopError::Executor(ExecutorError::ExecutionError(format!(
             "model call body serialize: {e}"
         )))
     })?;
+    let model = request_payload
+        .get("model")
+        .and_then(|m| m.as_str())
+        .unwrap_or("")
+        .to_string();
+    let api_key = target.api_key.clone().unwrap_or_default();
 
-    let mut builder = axum::http::Request::builder()
-        .method(axum::http::Method::POST)
-        .uri(&target.url)
-        .header(axum::http::header::CONTENT_TYPE, "application/json");
-    if stream_mode {
-        builder = builder.header(axum::http::header::ACCEPT, "text/event-stream");
-    }
-    if let Some(key) = &target.api_key {
-        builder = builder.header(AUTHORIZATION, format!("Bearer {key}"));
-    }
-    let req = builder.body(Body::from(body_bytes)).map_err(|e| {
-        LoopError::Executor(ExecutorError::ExecutionError(format!(
-            "model call request build: {e}"
-        )))
-    })?;
+    // Fusillade's RequestData is the input shape its HttpClient
+    // implementations consume. Most fields don't matter for the HTTP
+    // fire itself — they're metadata fusillade stamps as `x-fusillade-*`
+    // headers for analytics correlation. The two that DO matter for the
+    // wire are `endpoint + path` (URL composition) and `body`. `id` is
+    // load-bearing because it becomes the `X-Fusillade-Request-Id`
+    // header that lines the analytics row up with the sub-request row.
+    let request_data = RequestData {
+        id: sub_request_id,
+        batch_id: None,
+        template_id: TemplateId(Uuid::nil()),
+        custom_id: None,
+        endpoint: target.endpoint.clone(),
+        method: "POST".to_string(),
+        path: target.path.clone(),
+        body,
+        model,
+        api_key: api_key.clone(),
+        created_by: String::new(),
+        batch_metadata: HashMap::new(),
+    };
 
-    let resp = http_client.request(req).await.map_err(|e| {
+    let response = if stream_mode {
+        // Bridge: the callback is synchronous (fusillade's contract — see
+        // its StreamEventCallback docstring) but the sink is async. Push
+        // LoopEvents through an unbounded mpsc; a drain future running
+        // concurrently with the model fire awaits them and forwards.
+        // When fusillade's `execute_with_event_callback` returns, the
+        // last Arc<dyn StreamEventCallback> drops, the Sender drops, the
+        // channel closes, and the drain future completes naturally.
+        let (event_tx, event_rx) = mpsc::unbounded_channel::<crate::streaming::LoopEvent>();
+        let callback: Arc<dyn StreamEventCallback> = Arc::new(SinkChannelCallback {
+            tx: event_tx,
+            step_sequence,
+        });
+        let drain_fut = async {
+            let mut rx = event_rx;
+            while let Some(event) = rx.recv().await {
+                if let Some(sink) = sink {
+                    crate::streaming::try_emit(sink, event).await;
+                }
+            }
+        };
+        let fire_fut =
+            http_client.execute_with_event_callback(&request_data, &api_key, Some(callback));
+        let (fire_result, _) = tokio::join!(fire_fut, drain_fut);
+        fire_result
+    } else {
+        http_client.execute(&request_data, &api_key).await
+    }
+    .map_err(|e| {
         LoopError::Executor(ExecutorError::ExecutionError(format!(
             "model call HTTP error: {e}"
         )))
     })?;
 
-    let status = resp.status();
-    if !status.is_success() {
-        let body_bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
-            .await
-            .map_err(|e| {
-                LoopError::Executor(ExecutorError::ExecutionError(format!(
-                    "model call body read: {e}"
-                )))
-            })?;
-        let body_text = String::from_utf8_lossy(&body_bytes).into_owned();
+    if response.status < 200 || response.status >= 300 {
         return Err(LoopError::Executor(ExecutorError::ExecutionError(format!(
-            "model call returned HTTP {status}: {body_text}"
+            "model call returned HTTP {}: {}",
+            response.status, response.body
         ))));
     }
 
-    if stream_mode {
-        consume_streaming_model_response(resp, sink, step_sequence).await
-    } else {
-        let body_bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
-            .await
-            .map_err(|e| {
-                LoopError::Executor(ExecutorError::ExecutionError(format!(
-                    "model call body read: {e}"
-                )))
-            })?;
-        serde_json::from_slice::<Value>(&body_bytes).map_err(|e| {
-            LoopError::Executor(ExecutorError::ExecutionError(format!(
-                "model call body parse: {e}"
-            )))
-        })
-    }
-}
-
-/// Read an upstream `stream: true` response chunk by chunk, forwarding
-/// token deltas to the sink (if any) and reassembling the final body
-/// via [`openai_reassembler::reassemble`] for storage.
-///
-/// We forward two kinds of deltas:
-/// - assistant text content → `response.output_text.delta`
-/// - tool_call arguments → `response.function_call_arguments.delta`
-///
-/// Both carry the originating `step_sequence` as the SSE `id:` so
-/// reconnect-with-cursor can resume.
-async fn consume_streaming_model_response(
-    resp: axum::response::Response,
-    sink: Option<&dyn EventSink>,
-    step_sequence: i64,
-) -> Result<Value, LoopError> {
-    use eventsource_stream::Eventsource;
-    use futures_util::StreamExt;
-
-    let mut events: Vec<eventsource_stream::Event> = Vec::new();
-    let mut sse = resp.into_body().into_data_stream().eventsource();
-
-    while let Some(item) = sse.next().await {
-        let event = item.map_err(|e| {
-            LoopError::Executor(ExecutorError::ExecutionError(format!(
-                "SSE parse error: {e}"
-            )))
-        })?;
-
-        // Upstream signals end-of-stream with `data: [DONE]`. The
-        // openai-reassembler crate handles these markers internally, so
-        // we just drop them from the forwarded set and leave them in
-        // the event vec (their `data` is `[DONE]`, not JSON, and would
-        // be rejected by `serde_json::from_str`).
-        if event.data == "[DONE]" {
-            events.push(event);
-            break;
-        }
-
-        if let Some(sink) = sink {
-            forward_chunk_deltas(sink, &event, step_sequence).await;
-        }
-        events.push(event);
-    }
-
-    let reassembled = openai_reassembler::reassemble(&events).map_err(|e| {
+    serde_json::from_str::<Value>(&response.body).map_err(|e| {
         LoopError::Executor(ExecutorError::ExecutionError(format!(
-            "reassemble model stream: {e}"
-        )))
-    })?;
-    serde_json::from_str::<Value>(&reassembled).map_err(|e| {
-        LoopError::Executor(ExecutorError::ExecutionError(format!(
-            "reassembled body parse: {e}"
+            "model call body parse: {e}"
         )))
     })
 }
 
-/// Inspect an upstream SSE event and forward any token deltas to the
-/// sink. Best-effort: malformed events are skipped silently; the
-/// reassembler will produce the canonical final body regardless.
-async fn forward_chunk_deltas(sink: &dyn EventSink, event: &eventsource_stream::Event, sequence: i64) {
+/// Synchronous [`StreamEventCallback`] that bridges fusillade's
+/// chunk-by-chunk SSE callbacks into onwards' async [`EventSink`]
+/// vocabulary via an unbounded mpsc channel. The drain side of the
+/// channel runs concurrently with the model fire (see
+/// [`fire_model_call`]) and forwards each event to the sink.
+///
+/// Unbounded send is fine here: token chunks are small and the consumer
+/// (an axum SSE response) processes them as fast as they arrive over
+/// HTTP chunked transfer. The actual upstream-throttling backpressure
+/// surface is the model itself, not the channel.
+struct SinkChannelCallback {
+    tx: mpsc::UnboundedSender<crate::streaming::LoopEvent>,
+    step_sequence: i64,
+}
+
+impl StreamEventCallback for SinkChannelCallback {
+    fn on_event(&self, event: &StreamEvent) {
+        for loop_event in delta_loop_events(event, self.step_sequence) {
+            // Drop events if the receiver was dropped — same best-effort
+            // semantic as `streaming::try_emit`'s closed-sink path.
+            let _ = self.tx.send(loop_event);
+        }
+    }
+}
+
+/// Translate one upstream SSE event into zero or more [`LoopEvent`]s.
+///
+/// Forwards two kinds of deltas:
+/// - assistant text content → `response.output_text.delta`
+/// - tool_call arguments → `response.function_call_arguments.delta`
+///
+/// Both carry the originating `step_sequence` as the SSE `id:` so
+/// reconnect-with-cursor can resume. Malformed events and the `[DONE]`
+/// marker return no events (fusillade's reassembler handles `[DONE]`
+/// internally).
+fn delta_loop_events(event: &StreamEvent, sequence: i64) -> Vec<crate::streaming::LoopEvent> {
+    use crate::streaming::{LoopEvent, LoopEventKind};
+
+    let mut out = Vec::new();
     let parsed: Value = match serde_json::from_str(&event.data) {
         Ok(v) => v,
-        Err(_) => return,
+        Err(_) => return out,
     };
-
     let choices = match parsed.get("choices").and_then(|c| c.as_array()) {
         Some(arr) if !arr.is_empty() => arr,
-        _ => return,
+        _ => return out,
     };
-
     let delta = match choices[0].get("delta") {
         Some(d) => d,
-        None => return,
+        None => return out,
     };
 
     if let Some(text) = delta.get("content").and_then(|c| c.as_str())
         && !text.is_empty()
     {
-        crate::streaming::try_emit(
-            sink,
-            crate::streaming::LoopEvent {
-                sequence,
-                kind: crate::streaming::LoopEventKind::OutputTextDelta,
-                data: serde_json::json!({"delta": text}),
-            },
-        )
-        .await;
+        out.push(LoopEvent {
+            sequence,
+            kind: LoopEventKind::OutputTextDelta,
+            data: serde_json::json!({"delta": text}),
+        });
     }
 
     if let Some(tool_calls) = delta.get("tool_calls").and_then(|t| t.as_array()) {
@@ -665,18 +695,16 @@ async fn forward_chunk_deltas(sink: &dyn EventSink, event: &eventsource_stream::
                     .get("id")
                     .and_then(|x| x.as_str())
                     .unwrap_or("call_unknown");
-                crate::streaming::try_emit(
-                    sink,
-                    crate::streaming::LoopEvent {
-                        sequence,
-                        kind: crate::streaming::LoopEventKind::FunctionCallArgumentsDelta,
-                        data: serde_json::json!({"call_id": call_id, "delta": args}),
-                    },
-                )
-                .await;
+                out.push(LoopEvent {
+                    sequence,
+                    kind: LoopEventKind::FunctionCallArgumentsDelta,
+                    data: serde_json::json!({"call_id": call_id, "delta": args}),
+                });
             }
         }
     }
+
+    out
 }
 
 fn translate_tool_error(e: ToolError) -> ExecutorError {

--- a/src/response_loop_tests.rs
+++ b/src/response_loop_tests.rs
@@ -425,7 +425,7 @@ async fn fail_immediately_returns_loop_error_failed() {
 
 #[tokio::test]
 async fn single_model_call_then_complete_routes_through_real_http_client() {
-    // Exercises the model fire path: real onwards HttpClient (HyperClient)
+    // Exercises the model fire path: real fusillade ReqwestHttpClient
     // POSTs to wiremock, body parsed back into the step's response_payload.
     let (_model, endpoint, path) = model_wiremock(vec![json!({"output": "hello"})]).await;
 

--- a/src/response_loop_tests.rs
+++ b/src/response_loop_tests.rs
@@ -6,23 +6,26 @@
 //! per-step results, and declares each tool's [`ToolKind`] so the
 //! loop's HTTP-vs-Agent dispatch can be exercised.
 //!
-//! Model calls are fired via onwards' real `HttpClient` trait against
-//! a wiremock server, so the loop's HTTP path is exercised by the
-//! same code that handles single-step proxying.
+//! Model calls are fired via fusillade's `ReqwestHttpClient` against a
+//! wiremock server, so the loop's HTTP path is exercised by the same
+//! code production uses for batch / single-step fires (which gets us
+//! header-stamping for free).
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use async_trait::async_trait;
+use fusillade::{RequestId, ReqwestHttpClient};
 use serde_json::json;
+use uuid::Uuid;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-use crate::client::create_hyper_client;
 use crate::response_loop::{LoopConfig, LoopError, UpstreamTarget, run_response_loop};
 use crate::traits::{
-    ChainStep, MultiStepStore, NextAction, RecordedStep, RequestContext, StepDescriptor,
-    StepKind, StepState, StoreError, ToolError, ToolExecutor, ToolKind, ToolSchema,
+    ChainStep, MultiStepStore, NextAction, RecordedStep, RequestContext, StepDescriptor, StepKind,
+    StepState, StoreError, ToolError, ToolExecutor, ToolKind, ToolSchema,
 };
 
 #[derive(Debug, Default)]
@@ -139,7 +142,19 @@ impl MultiStepStore for MockStore {
             },
         );
         state.record_order.push(id.clone());
-        Ok(RecordedStep { id, sequence })
+        // Mirror the storage contract: model_call steps allocate a
+        // fusillade sub-request row; tool_call steps don't. Tests don't
+        // verify the UUID value itself — they only need it to be `Some`
+        // so `execute_step` doesn't bail with "missing sub_request_id".
+        let sub_request_id = match descriptor.kind {
+            StepKind::ModelCall => Some(RequestId(Uuid::new_v4())),
+            StepKind::ToolCall => None,
+        };
+        Ok(RecordedStep {
+            id,
+            sequence,
+            sub_request_id,
+        })
     }
 
     async fn mark_step_processing(&self, step_id: &str) -> Result<(), StoreError> {
@@ -300,9 +315,11 @@ fn tool_call(name: &str, args: serde_json::Value) -> StepDescriptor {
 }
 
 /// Spin up a wiremock server that returns a sequence of model
-/// responses on POSTs to /chat. Returns the server (kept alive) and
-/// the URL.
-async fn model_wiremock(responses: Vec<serde_json::Value>) -> (MockServer, String) {
+/// responses on POSTs to /chat. Returns the server (kept alive), the
+/// `endpoint` (host base) and `path` (`/chat`) for use as
+/// [`UpstreamTarget`] fields — fusillade's HttpClient consumes them
+/// separately, and its streaming dispatch keys on `path`.
+async fn model_wiremock(responses: Vec<serde_json::Value>) -> (MockServer, String, String) {
     let server = MockServer::start().await;
     for body in responses {
         Mock::given(method("POST"))
@@ -312,12 +329,36 @@ async fn model_wiremock(responses: Vec<serde_json::Value>) -> (MockServer, Strin
             .mount(&server)
             .await;
     }
-    let url = format!("{}/chat", server.uri());
-    (server, url)
+    let endpoint = server.uri();
+    (server, endpoint, "/chat".to_string())
 }
 
-fn http_client_for_tests() -> Arc<dyn crate::client::HttpClient + Send + Sync> {
-    Arc::new(create_hyper_client(10, 30))
+/// HTTP client for tests — fusillade's real `ReqwestHttpClient` with
+/// generous timeouts. `streamable_endpoints` is empty so every fire
+/// goes through the buffered branch by default (wiremock-returned
+/// non-SSE JSON bodies would otherwise be passed to the SSE
+/// reassembler and produce empty chunks). The streaming test wires up
+/// its own client via `streaming_http_client_for_tests`.
+fn http_client_for_tests() -> Arc<ReqwestHttpClient> {
+    Arc::new(ReqwestHttpClient::new(
+        Duration::from_secs(30),
+        Duration::from_secs(30),
+        Duration::from_secs(60),
+        Vec::new(),
+    ))
+}
+
+/// Client variant for the streaming SSE test: marks `/chat` streamable
+/// so fusillade reads the wiremock SSE response chunk-by-chunk and the
+/// per-event callback drives the sink-forwarding bridge in
+/// `fire_model_call`.
+fn streaming_http_client_for_tests() -> Arc<ReqwestHttpClient> {
+    Arc::new(ReqwestHttpClient::new(
+        Duration::from_secs(30),
+        Duration::from_secs(30),
+        Duration::from_secs(60),
+        vec!["/chat".to_string()],
+    ))
 }
 
 #[tokio::test]
@@ -326,7 +367,8 @@ async fn complete_immediately_returns_payload() {
     let tool_exec = ScriptedToolExecutor::new();
     let ctx = RequestContext::new();
     let target = UpstreamTarget {
-        url: "http://unused".into(),
+        endpoint: "http://unused".into(),
+        path: "/chat".into(),
         api_key: None,
     };
     store.script(None, vec![NextAction::Complete(json!({"final": true}))]);
@@ -356,7 +398,8 @@ async fn fail_immediately_returns_loop_error_failed() {
     let tool_exec = ScriptedToolExecutor::new();
     let ctx = RequestContext::new();
     let target = UpstreamTarget {
-        url: "http://unused".into(),
+        endpoint: "http://unused".into(),
+        path: "/chat".into(),
         api_key: None,
     };
     store.script(None, vec![NextAction::Fail(json!({"reason": "bad"}))]);
@@ -384,13 +427,14 @@ async fn fail_immediately_returns_loop_error_failed() {
 async fn single_model_call_then_complete_routes_through_real_http_client() {
     // Exercises the model fire path: real onwards HttpClient (HyperClient)
     // POSTs to wiremock, body parsed back into the step's response_payload.
-    let (_model, url) = model_wiremock(vec![json!({"output": "hello"})]).await;
+    let (_model, endpoint, path) = model_wiremock(vec![json!({"output": "hello"})]).await;
 
     let store = MockStore::new();
     let tool_exec = ScriptedToolExecutor::new();
     let ctx = RequestContext::new();
     let target = UpstreamTarget {
-        url,
+        endpoint,
+        path,
         api_key: None,
     };
     store.script(
@@ -435,7 +479,8 @@ async fn parallel_fan_out_chains_prev_step_id() {
     tool_exec.register("c", ToolKind::Http);
     let ctx = RequestContext::new();
     let target = UpstreamTarget {
-        url: "http://unused".into(),
+        endpoint: "http://unused".into(),
+        path: "/chat".into(),
         api_key: None,
     };
 
@@ -499,7 +544,8 @@ async fn step_failure_does_not_abort_loop() {
     let tool_exec = ScriptedToolExecutor::new();
     let ctx = RequestContext::new();
     let target = UpstreamTarget {
-        url: format!("{}/chat", server.uri()),
+        endpoint: server.uri(),
+        path: "/chat".into(),
         api_key: None,
     };
     store.script(
@@ -540,7 +586,8 @@ async fn max_iterations_cap_fires() {
     tool_exec.register("a", ToolKind::Http);
     let ctx = RequestContext::new();
     let target = UpstreamTarget {
-        url: "http://unused".into(),
+        endpoint: "http://unused".into(),
+        path: "/chat".into(),
         api_key: None,
     };
     let mut script = Vec::new();
@@ -580,7 +627,8 @@ async fn agent_kind_tool_triggers_recursion() {
     tool_exec.register("delegate", ToolKind::Agent);
     let ctx = RequestContext::new();
     let target = UpstreamTarget {
-        url: "http://unused".into(),
+        endpoint: "http://unused".into(),
+        path: "/chat".into(),
         api_key: None,
     };
     store.script(
@@ -631,7 +679,8 @@ async fn http_kind_tool_routes_through_tool_executor() {
     tool_exec.register("calculator", ToolKind::Http);
     let ctx = RequestContext::new();
     let target = UpstreamTarget {
-        url: "http://unused".into(),
+        endpoint: "http://unused".into(),
+        path: "/chat".into(),
         api_key: None,
     };
     store.script(
@@ -669,7 +718,8 @@ async fn empty_action_returns_empty_action_error() {
     let tool_exec = ScriptedToolExecutor::new();
     let ctx = RequestContext::new();
     let target = UpstreamTarget {
-        url: "http://unused".into(),
+        endpoint: "http://unused".into(),
+        path: "/chat".into(),
         api_key: None,
     };
     store.script(None, vec![NextAction::AppendSteps(vec![])]);
@@ -697,7 +747,8 @@ async fn resume_picks_up_chain_tail_for_prev_step_id() {
     tool_exec.register("a", ToolKind::Http);
     let ctx = RequestContext::new();
     let target = UpstreamTarget {
-        url: "http://unused".into(),
+        endpoint: "http://unused".into(),
+        path: "/chat".into(),
         api_key: None,
     };
 
@@ -713,7 +764,10 @@ async fn resume_picks_up_chain_tail_for_prev_step_id() {
         )
         .await
         .unwrap();
-    store.complete_step(&preexisting.id, &json!({"prior": true})).await.unwrap();
+    store
+        .complete_step(&preexisting.id, &json!({"prior": true}))
+        .await
+        .unwrap();
 
     store.script(
         None,
@@ -774,7 +828,8 @@ async fn streaming_model_call_forwards_token_deltas_and_emits_terminals() {
     let tool_exec = ScriptedToolExecutor::new();
     let ctx = RequestContext::new();
     let target = UpstreamTarget {
-        url: format!("{}/chat", server.uri()),
+        endpoint: server.uri(),
+        path: "/chat".into(),
         api_key: None,
     };
     let sink = RecordingSink::new();
@@ -795,7 +850,7 @@ async fn streaming_model_call_forwards_token_deltas_and_emits_terminals() {
         &tool_exec,
         &ctx,
         &target,
-        http_client_for_tests(),
+        streaming_http_client_for_tests(),
         Some(&sink),
         "req_1",
         None,
@@ -818,7 +873,11 @@ async fn streaming_model_call_forwards_token_deltas_and_emits_terminals() {
         kinds
     );
     assert!(
-        kinds.iter().filter(|k| **k == LoopEventKind::OutputTextDelta).count() >= 2,
+        kinds
+            .iter()
+            .filter(|k| **k == LoopEventKind::OutputTextDelta)
+            .count()
+            >= 2,
         "expected ≥2 OutputTextDelta events, got {:?}",
         kinds
     );
@@ -837,7 +896,10 @@ async fn streaming_model_call_forwards_token_deltas_and_emits_terminals() {
     assert_eq!(text_deltas, vec!["Hello".to_string(), " world".to_string()]);
 
     // The Created event has sequence 0 (the canonical start cursor).
-    let created = events.iter().find(|e| e.kind == LoopEventKind::Created).unwrap();
+    let created = events
+        .iter()
+        .find(|e| e.kind == LoopEventKind::Created)
+        .unwrap();
     assert_eq!(created.sequence, 0);
 }
 
@@ -850,7 +912,8 @@ async fn tool_call_emits_output_item_done_to_sink() {
     tool_exec.register("calculator", ToolKind::Http);
     let ctx = RequestContext::new();
     let target = UpstreamTarget {
-        url: "http://unused".into(),
+        endpoint: "http://unused".into(),
+        path: "/chat".into(),
         api_key: None,
     };
     let sink = RecordingSink::new();
@@ -884,7 +947,11 @@ async fn tool_call_emits_output_item_done_to_sink() {
         .filter(|e| e.kind == LoopEventKind::OutputItemDone)
         .filter(|e| e.data["type"] == "function_call_output")
         .collect();
-    assert_eq!(tool_done.len(), 1, "tool_call should emit one output_item.done");
+    assert_eq!(
+        tool_done.len(),
+        1,
+        "tool_call should emit one output_item.done"
+    );
     assert!(
         events.iter().any(|e| e.kind == LoopEventKind::Completed),
         "terminal Completed event should be emitted"
@@ -898,11 +965,15 @@ async fn non_streaming_model_call_emits_no_token_deltas() {
     // terminal events still fire.
     use crate::streaming::{LoopEventKind, RecordingSink};
 
-    let (_model, url) = model_wiremock(vec![json!({"output": "hello"})]).await;
+    let (_model, endpoint, path) = model_wiremock(vec![json!({"output": "hello"})]).await;
     let store = MockStore::new();
     let tool_exec = ScriptedToolExecutor::new();
     let ctx = RequestContext::new();
-    let target = UpstreamTarget { url, api_key: None };
+    let target = UpstreamTarget {
+        endpoint,
+        path,
+        api_key: None,
+    };
     let sink = RecordingSink::new();
 
     store.script(

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -13,10 +13,12 @@
 //!   tool's schema, and model calls are fired by the loop directly via
 //!   the configured HTTP client.
 
+#[cfg(feature = "multi-step")]
 mod multi_step_store;
 mod response_store;
 mod tool_executor;
 
+#[cfg(feature = "multi-step")]
 pub use multi_step_store::{
     ChainStep, ExecutorError, MultiStepStore, NextAction, RecordedStep, StepDescriptor, StepKind,
     StepState,

--- a/src/traits/multi_step_store.rs
+++ b/src/traits/multi_step_store.rs
@@ -26,6 +26,7 @@
 //! to touch [`MultiStepStore`] at all.
 
 use async_trait::async_trait;
+use fusillade::RequestId;
 use std::fmt;
 
 use super::response_store::StoreError;
@@ -95,10 +96,19 @@ pub enum NextAction {
 /// A step row recorded by [`MultiStepStore::record_step`]. Carries both
 /// the assigned id and its monotonic sequence value so the loop can chain
 /// siblings without a separate sequence-allocation round-trip.
+///
+/// For `model_call` steps, `sub_request_id` carries the
+/// `fusillade.requests` row id that the implementor created for this
+/// step's HTTP fire — the loop stamps it as `X-Fusillade-Request-Id` on
+/// the outgoing call so the `http_analytics` row produced by outlet
+/// middleware lines up with the right row in `requests`. For `tool_call`
+/// steps it's `None` (per the `response_steps` CHECK constraint —
+/// tool dispatch has its own analytics path).
 #[derive(Debug, Clone)]
 pub struct RecordedStep {
     pub id: String,
     pub sequence: i64,
+    pub sub_request_id: Option<RequestId>,
 }
 
 /// A read-only projection of a step row, returned by


### PR DESCRIPTION
**Changed files:**
- `Cargo.toml` — adds `multi-step` feature gating an optional `fusillade` dep (path-based for dev — switch to version-based before publishing).
- `src/lib.rs` — gates `response_loop` and `streaming` modules + their re-exports behind `#[cfg(feature = "multi-step")]`. Trait re-exports split: `ResponseStore`/`ToolExecutor` always exported, multi-step traits gated.
- `src/traits/mod.rs` — gates the `multi_step_store` submodule + its re-exports.
- `src/traits/multi_step_store.rs` — `RecordedStep` gains `sub_request_id: Option<fusillade::RequestId>` with docstring explaining the contract.
- `src/response_loop.rs` — the big one. `run_response_loop`, `execute_step`, `fire_model_call` become generic over `H: fusillade::HttpClient + 'static` (taking `Arc<H>`). `UpstreamTarget.url` splits into `endpoint`/`path` (fusillade keys streaming dispatch on `path`). `fire_model_call` builds a `RequestData` and calls `execute` / `execute_with_event_callback`. Streaming uses an internal `mpsc::unbounded_channel` bridge: sync `SinkChannelCallback` pushes per-event `LoopEvent`s; a drain future in the same task forwards them to the async `EventSink`. `consume_streaming_model_response` and `forward_chunk_deltas` are gone — replaced by `delta_loop_events` (pure sync translation function).
- `src/response_loop_tests.rs` — `MockStore::record_step` populates `sub_request_id` from the descriptor kind; helpers split into `http_client_for_tests` (empty `streamable_endpoints`) and `streaming_http_client_for_tests` (`/chat` streamable); `model_wiremock` returns endpoint + path separately.
- `Cargo.lock` — fusillade brought into the dependency graph under the feature.

**Verification:**
- `cargo test --lib` — 358 pass (default features, no multi-step in build, fusillade not pulled in).
- `cargo test --lib --features multi-step` — 371 pass (the 13 extra are the multi-step / streaming tests).
- `cargo fmt --check` and `cargo clippy -- -D warnings` — the failures present here also reproduce on plain `origin/main` against my local toolchain, so they're pre-existing local-vs-CI drift, not regressions from this PR.

**Notable design points:**
- The `multi_step_http_client` pattern in dwctl can collapse: production now passes the same `Arc<fusillade::ReqwestHttpClient>` it already uses for batches, and gets header-stamping for free.
- `SinkChannelCallback` is the bridge between fusillade's sync chunk callback and onwards' async `EventSink` — design rationale (chunk_timeout pollution if callback were async) is in the docstring.
- The `sub_request_id` ergonomic check in `execute_step` returns a clean `LoopError::Executor` rather than panicking if a `MultiStepStore` impl forgets to populate it for `ModelCall` — making the storage contract a soft type-error rather than a hard runtime crash.