### PR TITLE
docs: README section for multi-step Open Responses loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,83 @@ curl -X POST http://localhost:3000/v1/chat/completions \
 - Response sanitization for OpenAI schema compliance
 - Prometheus metrics
 - Custom response headers
+- Optional multi-step Open Responses orchestration loop (`multi-step` feature)
+
+## Multi-Step Open Responses
+
+The `multi-step` Cargo feature adds an orchestration loop that drives
+`/v1/responses`-style requests through one or more upstream model calls,
+optional server-side tool calls, and back — without onwards itself owning
+any persistence. The loop is a free function (`run_response_loop`) over
+two traits a consumer plugs in:
+
+- **`MultiStepStore`** — records steps, walks the chain, runs the
+  transition function (`next_action_for`: given the chain so far,
+  emit the next step, complete, or fail), and assembles the final
+  response. Implementing this trait is the host application's job;
+  the reference implementation in
+  [Doubleword's control-layer](https://github.com/doublewordai/control-layer)
+  is backed by [`fusillade`](https://crates.io/crates/fusillade) for
+  durable per-step rows.
+- **`ToolExecutor`** — the same trait onwards already uses for
+  single-step tool injection. The loop calls `execute` for
+  `ToolKind::Http` tools; `ToolKind::Agent` tools cause the loop to
+  recurse into a sub-loop under that tool's step id.
+
+Model calls fire through `fusillade::HttpClient` so each per-step HTTP
+request carries the `X-Fusillade-Request-Id` header that downstream
+analytics keys on. Streaming responses propagate live token deltas to
+an optional `EventSink` via fusillade's `StreamEventCallback` hook,
+so warm-path SSE clients still see chunks arrive in real time while
+fusillade owns reassembly into the canonical final body.
+
+### Enable
+
+```toml
+[dependencies]
+onwards = { version = "0.27", features = ["multi-step"] }
+fusillade = "17.0.2"
+```
+
+The feature is off by default — the simple `/ai/v1/*` proxy path doesn't
+need it and stays fusillade-free. Turning it on pulls in `fusillade` for
+`RequestData`, `HttpClient`, and the streaming-callback types.
+
+### Wire-up sketch
+
+```rust
+use onwards::{run_response_loop, LoopConfig, UpstreamTarget};
+use std::sync::Arc;
+
+let http_client = Arc::new(fusillade::ReqwestHttpClient::new(
+    /* first_chunk_timeout */ std::time::Duration::from_secs(30),
+    /* chunk_timeout */       std::time::Duration::from_secs(30),
+    /* body_timeout */        std::time::Duration::from_secs(120),
+    /* streamable_endpoints*/ vec!["/v1/chat/completions".into()],
+));
+
+let final_response = run_response_loop(
+    &store,           // your MultiStepStore impl
+    &tool_executor,   // your ToolExecutor impl
+    &tool_ctx,        // RequestContext carrying resolved tool config
+    &UpstreamTarget {
+        endpoint: "https://api.openai.com".into(),
+        path:     "/v1/chat/completions".into(),
+        api_key:  Some(api_key.to_string()),
+    },
+    http_client,
+    /* event_sink */  None, // Some(&sink) for streaming
+    request_id,
+    /* scope_parent */ None,
+    LoopConfig::default(),
+    /* depth */ 0,
+).await?;
+```
+
+Each model_call step's `RecordedStep` carries a `sub_request_id` —
+the `fusillade.requests` row id the store created for that step —
+which the loop stamps on the outgoing HTTP fire so per-step analytics
+line up with the right row in the database.
 
 ## Performance Tuning
 


### PR DESCRIPTION
## Summary

Add a README section documenting the upcoming `multi-step` Cargo feature: what it does, what consumers plug in, the wire-up shape, and why model_calls fire through `fusillade::HttpClient`.

## What's covered

- **Feature flag** — `multi-step` is opt-in, off by default. Proxy-only consumers stay fusillade-free.
- **Two traits a consumer plugs in:**
  - `MultiStepStore` — records steps, walks the chain, runs the transition function, assembles the response. Reference impl is in [control-layer](https://github.com/doublewordai/control-layer) backed by [`fusillade`](https://crates.io/crates/fusillade).
  - `ToolExecutor` — same trait onwards already uses; `ToolKind::Http` dispatches normally, `ToolKind::Agent` causes the loop to recurse.
- **Streaming** — model fires go through fusillade so the `X-Fusillade-Request-Id` header is stamped consistently, and live token deltas reach the optional `EventSink` via the `StreamEventCallback` bridge while fusillade owns reassembly.
- **Wire-up sketch** — minimal `run_response_loop` call site showing how to construct `Arc<fusillade::ReqwestHttpClient>`, `UpstreamTarget { endpoint, path, api_key }`, and `LoopConfig`.

## Sequencing

This PR documents functionality added by [#188](https://github.com/doublewordai/onwards/pull/188) (`feat/multi-step-feature-flag`). Merge ordering doesn't matter for correctness — the README change describes a forthcoming feature — but if you'd rather not document an unmerged feature, hold this until #188 lands.

## Test plan

- [x] No code changes; lint/test unaffected.
- [ ] Rendered preview on the PR page reads cleanly (headings nest correctly under `## Multi-Step Open Responses`, code blocks render as Rust/TOML).