### PR TITLE
feat: per-upstream opt-in for trace context propagation

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -24,6 +24,7 @@ Onwards is configured through a JSON file. Each key in the `targets` object defi
 | `upstream_auth_header_prefix` | string | No | Custom prefix for upstream auth header value (default: `Bearer `) |
 | `response_headers` | object | No | Key-value pairs to add or override in the response headers |
 | `sanitize_response` | bool | No | Enforce strict OpenAI schema compliance for responses only (see [Sanitization](sanitization.md)) |
+| `propagate_trace_context` | bool | No | Inject W3C `traceparent` / `tracestate` headers on outbound requests. Omit to inherit from resolved `trusted`. See [Trace context propagation](load-balancing.md#trace-context-propagation). |
 | `strategy` | string | No | Load balancing strategy: `weighted_random` or `priority` |
 | `fallback` | object | No | Retry configuration (see [Load Balancing](load-balancing.md)) |
 | `providers` | array | No | Array of provider configurations for load balancing |

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -24,7 +24,7 @@ Onwards is configured through a JSON file. Each key in the `targets` object defi
 | `upstream_auth_header_prefix` | string | No | Custom prefix for upstream auth header value (default: `Bearer `) |
 | `response_headers` | object | No | Key-value pairs to add or override in the response headers |
 | `sanitize_response` | bool | No | Enforce strict OpenAI schema compliance for responses only (see [Sanitization](sanitization.md)) |
-| `propagate_trace_context` | bool | No | Inject W3C `traceparent` / `tracestate` headers on outbound requests. Omit to inherit from resolved `trusted`. See [Trace context propagation](load-balancing.md#trace-context-propagation). |
+| `propagate_trace_context` | optional bool | No | Inject W3C `traceparent` / `tracestate` headers on outbound requests; omit to inherit from the resolved `trusted` value. **Provider-scoped:** valid on a single-provider target and on each entry of a pool's `providers` array — *not* as a top-level key on a pool that uses `providers`. See [Trace context propagation](load-balancing.md#trace-context-propagation). |
 | `strategy` | string | No | Load balancing strategy: `weighted_random` or `priority` |
 | `fallback` | object | No | Retry configuration (see [Load Balancing](load-balancing.md)) |
 | `providers` | array | No | Array of provider configurations for load balancing |

--- a/docs/src/load-balancing.md
+++ b/docs/src/load-balancing.md
@@ -74,6 +74,37 @@ Settings specific to each provider:
 | `concurrency_limit` | Provider-specific concurrency limit |
 | `response_headers` | Provider-specific headers |
 | `trusted` | Override pool-level trust for strict mode error sanitization (`true`/`false`; omit to inherit from pool) |
+| `propagate_trace_context` | Whether to inject W3C `traceparent` / `tracestate` headers on outbound requests to this provider (`true`/`false`; omit to inherit from the resolved `trusted` value). Useful for preventing trace IDs from leaking to third-party providers whose downstream HTTP fetches would re-emit them. See [Trace context propagation](#trace-context-propagation) below. |
+
+## Trace context propagation
+
+`onwards` forwards W3C trace context (`traceparent` and `tracestate`
+headers) on outbound requests to upstream providers, so a downstream
+service that participates in your distributed tracing fabric can stitch
+its spans into the calling trace.
+
+Whether the headers are sent is controlled by `propagate_trace_context`:
+
+- `propagate_trace_context: true` — always propagate
+- `propagate_trace_context: false` — never propagate
+- *omitted* (default) — inherit from the resolved `trusted` value:
+  - per-provider `trusted: true|false` overrides
+  - falling back to the pool-level `trusted` (default `false`)
+
+In effect: **trusted upstreams receive trace context by default;
+untrusted upstreams do not**. This prevents trace IDs from leaking to
+third-party services that may re-emit them on their own outbound
+calls (e.g., a provider's image fetcher echoing your `traceparent`
+back to whatever URL the caller supplied).
+
+> **Migration note.** Prior to onwards v0.28, `traceparent` was
+> propagated to every upstream unconditionally. After this change,
+> non-trusted pools no longer propagate by default. If you rely on
+> trace continuity across `onwards → upstream` and your upstream
+> isn't marked `trusted: true`, add `propagate_trace_context: true`
+> at the provider or pool level (the field is honoured in both
+> `PoolSpec.providers` entries and the legacy single-provider
+> `TargetSpec` shape).
 
 ## Examples
 

--- a/docs/src/load-balancing.md
+++ b/docs/src/load-balancing.md
@@ -99,12 +99,16 @@ back to whatever URL the caller supplied).
 
 > **Migration note.** Prior to onwards v0.28, `traceparent` was
 > propagated to every upstream unconditionally. After this change,
-> non-trusted pools no longer propagate by default. If you rely on
-> trace continuity across `onwards → upstream` and your upstream
-> isn't marked `trusted: true`, add `propagate_trace_context: true`
-> at the provider or pool level (the field is honoured in both
-> `PoolSpec.providers` entries and the legacy single-provider
-> `TargetSpec` shape).
+> non-trusted upstreams no longer propagate by default (and any inbound
+> trace context is stripped before forwarding to them). If you rely on
+> trace continuity across `onwards → upstream` and the upstream isn't
+> marked `trusted: true`, set `propagate_trace_context: true` on that
+> provider. The field is **provider-scoped**: set it on each relevant
+> entry of a pool's `providers` array, or on a legacy single-provider
+> target. There is no pool-level `propagate_trace_context` key — for a
+> whole pool, mark the pool `trusted: true` (which both bypasses
+> error sanitization and enables propagation) or set the field on each
+> provider entry.
 
 ## Examples
 

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -104,14 +104,6 @@ struct OriginalModel(String);
 #[derive(Clone, Debug)]
 pub(crate) struct ResolvedTrust(pub(crate) bool);
 
-/// Filters and modifies headers before forwarding to upstream
-///
-/// This function implements RFC 7230 compliant proxy behavior by:
-/// - Removing hop-by-hop headers (connection, keep-alive, etc.)
-/// - Stripping authentication headers to prevent credential leakage
-/// - Removing browser-specific context headers (sec-*, origin, referer)
-/// - Adding upstream authentication if configured
-/// - Adding X-Forwarded-* headers for transparency
 /// Resolve whether W3C trace context headers should be propagated to an
 /// upstream provider. The per-provider `propagate_trace_context` overrides;
 /// when unset, defaults to the resolved trusted value (per-provider `trusted`
@@ -123,6 +115,14 @@ fn resolve_trace_propagation(target: &Target, pool_trusted: bool) -> bool {
         .unwrap_or_else(|| target.trusted.unwrap_or(pool_trusted))
 }
 
+/// Filters and modifies headers before forwarding to upstream
+///
+/// This function implements RFC 7230 compliant proxy behavior by:
+/// - Removing hop-by-hop headers (connection, keep-alive, etc.)
+/// - Stripping authentication headers to prevent credential leakage
+/// - Removing browser-specific context headers (sec-*, origin, referer)
+/// - Adding upstream authentication if configured
+/// - Adding X-Forwarded-* headers for transparency
 fn filter_headers_for_upstream(headers: &mut HeaderMap, target: &Target) {
     // Headers to remove: hop-by-hop (RFC 7230), auth, browser context, and routing headers
     const HEADERS_TO_STRIP: &[&str] = &[

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -115,6 +115,16 @@ fn resolve_trace_propagation(target: &Target, pool_trusted: bool) -> bool {
         .unwrap_or_else(|| target.trusted.unwrap_or(pool_trusted))
 }
 
+/// Remove W3C trace-context headers (`traceparent`, `tracestate`) from the
+/// outbound header set. Used when trace propagation is disabled for an
+/// upstream, so an inbound trace context from the caller is not forwarded to
+/// (and re-emitted by) an untrusted third party. Extracted as a pure
+/// function for unit testing.
+fn withhold_trace_context(headers: &mut HeaderMap) {
+    headers.remove("traceparent");
+    headers.remove("tracestate");
+}
+
 /// Filters and modifies headers before forwarding to upstream
 ///
 /// This function implements RFC 7230 compliant proxy behavior by:
@@ -624,18 +634,28 @@ pub async fn target_message_handler<T: HttpClient>(
         // Filter headers for upstream forwarding
         filter_headers_for_upstream(&mut attempt_headers, target);
 
-        // Inject W3C traceparent + tracestate headers for distributed tracing,
-        // gated on the per-target propagate_trace_context flag (defaults to the
-        // resolved trusted value). This propagates the current span context to
-        // upstreams that participate in our distributed tracing fabric
-        // (typically self-hosted, marked trusted), while withholding it from
-        // upstreams that do not — preventing trace IDs from being forwarded to
-        // third parties that re-emit them on their own outbound calls.
+        // Apply W3C trace-context policy for this upstream, gated on the
+        // per-target propagate_trace_context flag (defaults to the resolved
+        // trusted value).
+        //
+        // - Enabled: inject the current span context, propagating the trace to
+        //   upstreams that participate in our distributed tracing fabric
+        //   (typically self-hosted, marked trusted). inject_context overwrites
+        //   any inbound traceparent/tracestate.
+        // - Disabled: strip any *inbound* traceparent/tracestate so they are
+        //   not forwarded to an untrusted third party. These headers are not
+        //   in HEADERS_TO_STRIP (they're handled here, next to the inject
+        //   decision), so without this branch an inbound trace context from
+        //   the caller would pass straight through, defeating the opt-out and
+        //   letting the third party re-emit our trace IDs on its own outbound
+        //   calls.
         if resolve_trace_propagation(target, pool.is_trusted()) {
             use tracing_opentelemetry::OpenTelemetrySpanExt;
             let ctx = tracing::Span::current().context();
             let propagator = opentelemetry_sdk::propagation::TraceContextPropagator::new();
             propagator.inject_context(&ctx, &mut HeaderInjector(&mut attempt_headers));
+        } else {
+            withhold_trace_context(&mut attempt_headers);
         }
 
         // Build the request
@@ -1922,5 +1942,30 @@ mod tests {
         let target = target_with_trace_flags(None, None);
         assert!(resolve_trace_propagation(&target, true));
         assert!(!resolve_trace_propagation(&target, false));
+    }
+
+    #[test]
+    fn withhold_trace_context_strips_inbound_trace_headers() {
+        // When propagation is disabled for an upstream, an inbound trace
+        // context (e.g. from the caller) must not be forwarded.
+        let mut headers = HeaderMap::new();
+        headers.insert("traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01".parse().unwrap());
+        headers.insert("tracestate", "vendor=value".parse().unwrap());
+        headers.insert("content-type", "application/json".parse().unwrap());
+
+        withhold_trace_context(&mut headers);
+
+        assert!(!headers.contains_key("traceparent"), "traceparent must be stripped");
+        assert!(!headers.contains_key("tracestate"), "tracestate must be stripped");
+        // Unrelated headers are left untouched.
+        assert!(headers.contains_key("content-type"), "non-trace headers must be preserved");
+    }
+
+    #[test]
+    fn withhold_trace_context_is_noop_when_absent() {
+        let mut headers = HeaderMap::new();
+        headers.insert("content-type", "application/json".parse().unwrap());
+        withhold_trace_context(&mut headers);
+        assert_eq!(headers.len(), 1);
     }
 }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -112,6 +112,17 @@ pub(crate) struct ResolvedTrust(pub(crate) bool);
 /// - Removing browser-specific context headers (sec-*, origin, referer)
 /// - Adding upstream authentication if configured
 /// - Adding X-Forwarded-* headers for transparency
+/// Resolve whether W3C trace context headers should be propagated to an
+/// upstream provider. The per-provider `propagate_trace_context` overrides;
+/// when unset, defaults to the resolved trusted value (per-provider `trusted`
+/// falling back to the pool-level setting). Extracted as a pure function for
+/// unit testing.
+fn resolve_trace_propagation(target: &Target, pool_trusted: bool) -> bool {
+    target
+        .propagate_trace_context
+        .unwrap_or_else(|| target.trusted.unwrap_or(pool_trusted))
+}
+
 fn filter_headers_for_upstream(headers: &mut HeaderMap, target: &Target) {
     // Headers to remove: hop-by-hop (RFC 7230), auth, browser context, and routing headers
     const HEADERS_TO_STRIP: &[&str] = &[
@@ -613,10 +624,14 @@ pub async fn target_message_handler<T: HttpClient>(
         // Filter headers for upstream forwarding
         filter_headers_for_upstream(&mut attempt_headers, target);
 
-        // Inject W3C traceparent + tracestate headers for distributed tracing.
-        // This propagates the current span context to upstream services (e.g. vLLM),
-        // creating a continuous trace: fusillade → dwctl → onwards → vLLM
-        {
+        // Inject W3C traceparent + tracestate headers for distributed tracing,
+        // gated on the per-target propagate_trace_context flag (defaults to the
+        // resolved trusted value). This propagates the current span context to
+        // upstreams that participate in our distributed tracing fabric
+        // (typically self-hosted, marked trusted), while withholding it from
+        // upstreams that do not — preventing trace IDs from being forwarded to
+        // third parties that re-emit them on their own outbound calls.
+        if resolve_trace_propagation(target, pool.is_trusted()) {
             use tracing_opentelemetry::OpenTelemetrySpanExt;
             let ctx = tracing::Span::current().context();
             let propagator = opentelemetry_sdk::propagation::TraceContextPropagator::new();
@@ -1857,5 +1872,55 @@ mod tests {
 
         assert!(pool.fallback_enabled(), "Fallback should be enabled");
         assert_eq!(pool.len(), 2, "Pool should have 2 providers");
+    }
+
+    /// Helper: build a minimal target with the requested trace flags.
+    fn target_with_trace_flags(
+        trusted: Option<bool>,
+        propagate_trace_context: Option<bool>,
+    ) -> Target {
+        Target {
+            url: "https://api.example.com/".parse().unwrap(),
+            keys: None,
+            onwards_key: None,
+            onwards_model: None,
+            limiter: None,
+            upstream_auth_header_name: None,
+            upstream_auth_header_prefix: None,
+            response_headers: None,
+            sanitize_response: false,
+            open_responses: None,
+            request_timeout_secs: None,
+            trusted,
+            propagate_trace_context,
+        }
+    }
+
+    #[test]
+    fn resolve_trace_propagation_explicit_true_overrides_untrusted_pool() {
+        let target = target_with_trace_flags(Some(false), Some(true));
+        assert!(resolve_trace_propagation(&target, false));
+    }
+
+    #[test]
+    fn resolve_trace_propagation_explicit_false_overrides_trusted_pool() {
+        let target = target_with_trace_flags(Some(true), Some(false));
+        assert!(!resolve_trace_propagation(&target, true));
+    }
+
+    #[test]
+    fn resolve_trace_propagation_inherits_from_target_trusted_when_unset() {
+        let target = target_with_trace_flags(Some(true), None);
+        assert!(resolve_trace_propagation(&target, false));
+
+        let target = target_with_trace_flags(Some(false), None);
+        assert!(!resolve_trace_propagation(&target, true));
+    }
+
+    #[test]
+    fn resolve_trace_propagation_inherits_from_pool_when_target_unset() {
+        let target = target_with_trace_flags(None, None);
+        assert!(resolve_trace_propagation(&target, true));
+        assert!(!resolve_trace_propagation(&target, false));
     }
 }

--- a/src/target.rs
+++ b/src/target.rs
@@ -88,6 +88,15 @@ pub struct ProviderSpec {
     /// When None (default), inherits the pool-level `trusted` setting.
     #[serde(default)]
     pub trusted: Option<bool>,
+
+    /// Propagate W3C trace context (traceparent / tracestate) on outbound
+    /// requests to this provider. When unset, defaults to the resolved
+    /// `trusted` value — providers participating in our distributed tracing
+    /// fabric (typically self-hosted upstreams marked `trusted: true`) receive
+    /// trace context; external providers do not. Explicit `Some(true)` /
+    /// `Some(false)` overrides the inherited value.
+    #[serde(default)]
+    pub propagate_trace_context: Option<bool>,
 }
 
 /// Configuration for Open Responses API behavior
@@ -346,6 +355,7 @@ impl TargetSpecOrList {
                         open_responses: t.open_responses,
                         request_timeout_secs: t.request_timeout_secs,
                         trusted: None, // pool-level trusted handles this for legacy format
+                        propagate_trace_context: None, // inherits from resolved trusted
                     })
                     .collect();
                 Ok(PoolConfig {
@@ -382,6 +392,7 @@ impl TargetSpecOrList {
                     open_responses: open_responses.clone(),
                     request_timeout_secs: spec.request_timeout_secs,
                     trusted: None, // pool-level trusted handles this for single-provider format
+                    propagate_trace_context: None, // inherits from resolved trusted
                 };
                 Ok(PoolConfig {
                     keys,
@@ -435,6 +446,7 @@ impl From<TargetSpec> for Target {
             open_responses: value.open_responses,
             request_timeout_secs: value.request_timeout_secs,
             trusted: None,
+            propagate_trace_context: None,
         }
     }
 }
@@ -459,6 +471,7 @@ impl From<ProviderSpec> for Target {
             open_responses: value.open_responses,
             request_timeout_secs: value.request_timeout_secs,
             trusted: value.trusted,
+            propagate_trace_context: value.propagate_trace_context,
         }
     }
 }
@@ -604,6 +617,9 @@ pub struct Target {
     /// Per-provider override for strict mode error sanitization trust.
     /// None means inherit from the pool-level trusted setting.
     pub trusted: Option<bool>,
+    /// Per-provider override for W3C trace context propagation on outbound
+    /// requests. None means inherit from the resolved trusted value.
+    pub propagate_trace_context: Option<bool>,
 }
 
 impl Target {
@@ -2144,6 +2160,7 @@ mod tests {
                 open_responses: None,
                 request_timeout_secs: None,
                 trusted: None,
+                propagate_trace_context: None,
             }],
         };
 

--- a/src/target.rs
+++ b/src/target.rs
@@ -267,6 +267,13 @@ pub struct TargetSpec {
     #[builder(default)]
     pub trusted: bool,
 
+    /// Propagate W3C trace context (traceparent / tracestate) on outbound
+    /// requests to this provider. Same semantics as `ProviderSpec`'s
+    /// equivalent field — when unset, defaults to the resolved trusted
+    /// value. Honoured for the legacy single-provider config format.
+    #[serde(default)]
+    pub propagate_trace_context: Option<bool>,
+
     /// Request timeout in seconds. If specified, requests exceeding this duration
     /// will be cancelled and return a 504 Gateway Timeout error.
     /// If fallback is enabled, the next provider will be tried.
@@ -392,7 +399,10 @@ impl TargetSpecOrList {
                     open_responses: open_responses.clone(),
                     request_timeout_secs: spec.request_timeout_secs,
                     trusted: None, // pool-level trusted handles this for single-provider format
-                    propagate_trace_context: None, // inherits from resolved trusted
+                    // Carry the legacy spec's explicit override (if any). Without
+                    // this, setting propagate_trace_context on the single-provider
+                    // YAML form would be silently dropped.
+                    propagate_trace_context: spec.propagate_trace_context,
                 };
                 Ok(PoolConfig {
                     keys,
@@ -446,7 +456,7 @@ impl From<TargetSpec> for Target {
             open_responses: value.open_responses,
             request_timeout_secs: value.request_timeout_secs,
             trusted: None,
-            propagate_trace_context: None,
+            propagate_trace_context: value.propagate_trace_context,
         }
     }
 }

--- a/src/target.rs
+++ b/src/target.rs
@@ -362,7 +362,11 @@ impl TargetSpecOrList {
                         open_responses: t.open_responses,
                         request_timeout_secs: t.request_timeout_secs,
                         trusted: None, // pool-level trusted handles this for legacy format
-                        propagate_trace_context: None, // inherits from resolved trusted
+                        // Carry each provider's explicit override. Unlike `trusted`
+                        // (which is forced uniform to the pool level in legacy list
+                        // format), per-provider trace-context overrides are honoured;
+                        // an unset value still inherits the resolved trusted value.
+                        propagate_trace_context: t.propagate_trace_context,
                     })
                     .collect();
                 Ok(PoolConfig {
@@ -2234,6 +2238,29 @@ mod tests {
             "Error message should mention trusted value mismatch, got: {}",
             err_msg
         );
+    }
+
+    #[test]
+    fn test_legacy_list_carries_per_provider_propagate_trace_context() {
+        // Regression: the legacy list format must carry each provider's
+        // explicit `propagate_trace_context` through to the ProviderSpec
+        // (the `trusted` field is forced uniform in this format, but
+        // trace-context overrides are honoured per-provider). Previously
+        // this was dropped to None, silently ignoring operator config.
+        let list: TargetSpecOrList = serde_json::from_str(
+            r#"[
+                { "url": "https://provider1.example.com", "propagate_trace_context": true },
+                { "url": "https://provider2.example.com", "propagate_trace_context": false },
+                { "url": "https://provider3.example.com" }
+            ]"#,
+        )
+        .unwrap();
+
+        let pool_config = list.into_pool_config().unwrap();
+        assert_eq!(pool_config.providers.len(), 3);
+        assert_eq!(pool_config.providers[0].propagate_trace_context, Some(true), "explicit true must survive");
+        assert_eq!(pool_config.providers[1].propagate_trace_context, Some(false), "explicit false must survive");
+        assert_eq!(pool_config.providers[2].propagate_trace_context, None, "unset stays None (inherits resolved trusted)");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds an optional `propagate_trace_context: Option<bool>` field to `ProviderSpec` (mirrored on the runtime `Target`). When set, controls whether W3C `traceparent` / `tracestate` headers are injected on outbound requests to that upstream. When unset, inherits from the resolved `trusted` value — providers participating in our distributed tracing fabric (typically self-hosted upstreams marked `trusted: true`) receive trace context; external providers do not.

## Why

Trace headers being propagated to every upstream means a third-party we forward to receives our trace IDs and can re-emit them on its own downstream HTTP calls. This is undesirable for upstreams outside our tracing fabric. The fix is per-upstream opt-in rather than a blanket removal so internal observability stays intact.

## Behaviour

Pure helper `resolve_trace_propagation(target, pool_trusted) -> bool`:

- `Some(true)` → propagate, regardless of trust
- `Some(false)` → do not propagate, regardless of trust
- `None` (default) → inherit from resolved trusted: per-provider `trusted` falling back to pool-level

Existing configs without the new field parse unchanged and behave equivalently for trusted pools. Untrusted pools — previously always receiving trace context — stop propagating by default. Safer posture; opt back in per-upstream if needed.

## Test plan

- [x] Four new unit tests in `handlers::tests::resolve_trace_propagation_*`
- [x] All 375 existing tests still pass (new total 379)
- [x] `cargo build` clean
- [ ] CI on merge target