### PR TITLE
feat: configure max body size

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -113,6 +113,20 @@ impl OnwardsErrorResponse {
         }
     }
 
+    pub fn payload_too_large(limit: usize) -> Self {
+        OnwardsErrorResponse {
+            body: Some(ErrorResponseBody {
+                message: format!(
+                    "Request body too large: the maximum allowed size is {limit} bytes."
+                ),
+                r#type: "invalid_request_error".to_string(),
+                param: None,
+                code: "payload_too_large".to_string(),
+            }),
+            status: StatusCode::PAYLOAD_TOO_LARGE,
+        }
+    }
+
     pub fn unprocessable_request(message: &str, param: Option<&str>) -> Self {
         OnwardsErrorResponse {
             body: Some(ErrorResponseBody {

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -253,10 +253,12 @@ pub async fn target_message_handler<T: HttpClient>(
     // Extract the request body. TODO(fergus): make this step conditional: its not necessary if we
     // extract the model from the header.
     let mut body_bytes =
-        match axum::body::to_bytes(std::mem::take(req.body_mut()), usize::MAX).await {
+        match axum::body::to_bytes(std::mem::take(req.body_mut()), state.body_limit).await {
             Ok(bytes) => bytes,
-            Err(_) => return Err(OnwardsErrorResponse::internal()), // since there's no body limit,
-                                                                    // this should never fail.
+            // to_bytes only fails when the body exceeds the limit (or the
+            // connection drops mid-body); report it as an explicit 413 rather
+            // than an opaque 500.
+            Err(_) => return Err(OnwardsErrorResponse::payload_too_large(state.body_limit)),
         };
 
     // Apply body transformation if provided
@@ -1869,6 +1871,7 @@ mod tests {
             response_id_header: None,
             tool_executor: std::sync::Arc::new(crate::NoOpToolExecutor),
             response_store: std::sync::Arc::new(crate::NoOpResponseStore),
+            body_limit: crate::DEFAULT_BODY_LIMIT,
         };
 
         // Create a simple POST request

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@
 //!
 
 use axum::Router;
+use axum::extract::DefaultBodyLimit;
 use axum::http::HeaderMap;
 use axum::routing::{any, get};
 use axum_prometheus::{
@@ -225,7 +226,19 @@ pub struct AppState<T: HttpClient> {
     pub response_id_header: Option<String>,
     pub tool_executor: Arc<dyn ToolExecutor>,
     pub response_store: Arc<dyn ResponseStore>,
+    /// Maximum request body size in bytes, enforced by both routers. Without
+    /// this, the strict router's `Json` extractors fall back to Axum's 2 MB
+    /// `DefaultBodyLimit`, which rejects large (e.g. long-context or base64
+    /// image) payloads with a 413. Defaults to [`DEFAULT_BODY_LIMIT`].
+    pub body_limit: usize,
 }
+
+/// Default maximum request body size (32 MB).
+///
+/// Deliberately larger than Axum's 2 MB default so that long-context and
+/// vision payloads are not rejected out of the box. Override with
+/// [`AppState::with_body_limit`].
+pub const DEFAULT_BODY_LIMIT: usize = 32 * 1024 * 1024;
 
 impl<T: HttpClient> std::fmt::Debug for AppState<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -244,6 +257,7 @@ impl<T: HttpClient> std::fmt::Debug for AppState<T> {
             .field("response_id_header", &self.response_id_header)
             .field("tool_executor", &"<dyn ToolExecutor>")
             .field("response_store", &"<dyn ResponseStore>")
+            .field("body_limit", &self.body_limit)
             .finish()
     }
 }
@@ -267,6 +281,7 @@ impl AppState<HyperClient> {
             response_id_header: None,
             tool_executor: Arc::new(NoOpToolExecutor),
             response_store: Arc::new(NoOpResponseStore),
+            body_limit: DEFAULT_BODY_LIMIT,
         }
     }
 
@@ -288,6 +303,7 @@ impl AppState<HyperClient> {
             response_id_header: None,
             tool_executor: Arc::new(NoOpToolExecutor),
             response_store: Arc::new(NoOpResponseStore),
+            body_limit: DEFAULT_BODY_LIMIT,
         }
     }
 }
@@ -304,6 +320,7 @@ impl<T: HttpClient> AppState<T> {
             response_id_header: None,
             tool_executor: Arc::new(NoOpToolExecutor),
             response_store: Arc::new(NoOpResponseStore),
+            body_limit: DEFAULT_BODY_LIMIT,
         }
     }
 
@@ -322,6 +339,7 @@ impl<T: HttpClient> AppState<T> {
             response_id_header: None,
             tool_executor: Arc::new(NoOpToolExecutor),
             response_store: Arc::new(NoOpResponseStore),
+            body_limit: DEFAULT_BODY_LIMIT,
         }
     }
 
@@ -353,6 +371,13 @@ impl<T: HttpClient> AppState<T> {
     /// Set the response store for stateful conversations (builder pattern)
     pub fn with_response_store(mut self, store: Arc<dyn ResponseStore>) -> Self {
         self.response_store = store;
+        self
+    }
+
+    /// Set the maximum request body size in bytes (builder pattern).
+    /// Applies to both the strict and non-strict routers.
+    pub fn with_body_limit(mut self, limit: usize) -> Self {
+        self.body_limit = limit;
         self
     }
 }
@@ -497,6 +522,10 @@ pub fn build_router<T: HttpClient + Clone + Send + Sync + 'static>(state: AppSta
         .route("/models", get(models_handler))
         .route("/v1/models", get(models_handler))
         .route("/{*path}", any(target_message_handler))
+        // The wildcard handler buffers the body itself (bounded by
+        // `state.body_limit`), but raise the extractor-level default too so
+        // any extractor-based route added later shares the same limit.
+        .layer(DefaultBodyLimit::max(state.body_limit))
         .with_state(state)
 }
 
@@ -928,6 +957,51 @@ mod tests {
             .await;
 
         assert_eq!(response.status_code(), 404);
+    }
+
+    #[tokio::test]
+    async fn test_non_strict_router_rejects_body_over_configured_limit() {
+        let targets_map = Arc::new(DashMap::new());
+        targets_map.insert(
+            "gpt-4".to_string(),
+            pool(
+                target::Target::builder()
+                    .url("https://api.openai.com".parse().unwrap())
+                    .build(),
+            ),
+        );
+
+        let targets = target::Targets {
+            targets: targets_map,
+            key_rate_limiters: Arc::new(DashMap::new()),
+            key_concurrency_limiters: Arc::new(DashMap::new()),
+            key_labels: Arc::new(DashMap::new()),
+            strict_mode: false,
+            http_pool_config: None,
+        };
+
+        let mock_client = MockHttpClient::new(StatusCode::OK, "{}");
+        let app_state = AppState::with_client(targets, mock_client).with_body_limit(1024);
+        let router = build_router(app_state);
+        let server = TestServer::new(router).unwrap();
+
+        let response = server
+            .post("/v1/chat/completions")
+            .json(&json!({
+                "model": "gpt-4",
+                "messages": [{"role": "user", "content": "x".repeat(2048)}]
+            }))
+            .await;
+
+        assert_eq!(response.status_code(), StatusCode::PAYLOAD_TOO_LARGE);
+        let body: serde_json::Value = response.json();
+        assert_eq!(body["error"]["code"], "payload_too_large");
+        assert!(
+            body["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("1024 bytes")
+        );
     }
 
     #[tokio::test]

--- a/src/strict/mod.rs
+++ b/src/strict/mod.rs
@@ -127,6 +127,7 @@ pub(crate) fn merge_usage_details(
 use crate::AppState;
 use crate::client::HttpClient;
 use axum::Router;
+use axum::extract::DefaultBodyLimit;
 use axum::routing::{get, post};
 use tracing::info;
 
@@ -179,6 +180,9 @@ pub fn build_strict_router<T: HttpClient + Clone + Send + Sync + 'static>(
         .route("/responses", post(handlers::responses_handler::<T>))
         // Embeddings
         .route("/embeddings", post(handlers::embeddings_handler::<T>))
+        // Without this layer the `Json` extractors above fall back to Axum's
+        // 2 MB default and reject larger payloads with a 413.
+        .layer(DefaultBodyLimit::max(state.body_limit))
         .with_state(state)
 }
 
@@ -293,6 +297,79 @@ mod tests {
 
         let response = router.oneshot(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    /// Build a valid chat completions body padded to at least `size` bytes.
+    fn padded_chat_completions_body(size: usize) -> String {
+        let padding = "x".repeat(size);
+        format!(r#"{{"model": "gpt-4", "messages": [{{"role": "user", "content": "{padding}"}}]}}"#)
+    }
+
+    #[tokio::test]
+    async fn test_strict_router_accepts_body_over_axum_2mb_default() {
+        // Regression test: without an explicit DefaultBodyLimit layer the Json
+        // extractors fall back to Axum's 2 MB default and 413 anything larger.
+        let state = create_test_app_state();
+        let router = build_strict_router(state);
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/chat/completions")
+            .header("content-type", "application/json")
+            .body(Body::from(padded_chat_completions_body(3 * 1024 * 1024)))
+            .unwrap();
+
+        let response = router.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_strict_router_accepts_base64_image_over_axum_2mb_default() {
+        // The prod failure mode for COR-440: a vision request whose base64
+        // data URL pushes the body past Axum's old 2 MB extractor default.
+        // Also exercises the image_url content-part schema with a large URL.
+        let state = create_test_app_state();
+        let router = build_strict_router(state);
+
+        // ~3 MB of valid base64 (must be a multiple of 4 chars).
+        let base64_data = "QUJD".repeat(3 * 1024 * 1024 / 4);
+        let body = serde_json::json!({
+            "model": "gpt-4",
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "What is in this image?"},
+                    {"type": "image_url", "image_url": {"url": format!("data:image/jpeg;base64,{base64_data}")}}
+                ]
+            }]
+        });
+        assert!(body.to_string().len() > 2 * 1024 * 1024);
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/chat/completions")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+
+        let response = router.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_strict_router_rejects_body_over_configured_limit() {
+        let state = create_test_app_state().with_body_limit(1024);
+        let router = build_strict_router(state);
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/chat/completions")
+            .header("content-type", "application/json")
+            .body(Body::from(padded_chat_completions_body(2048)))
+            .unwrap();
+
+        let response = router.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
     }
 
     #[tokio::test]


### PR DESCRIPTION
# feat: add configurable request body limit (default 32 MB)

Fixes the onwards half of COR-440: realtime requests larger than 2 MB are
rejected with 413 in strict mode.

## Problem

`build_strict_router` registers `Json`-typed extractors with no
`DefaultBodyLimit` layer anywhere in the crate, so Axum's stock 2 MB default
applies. Any long-context or base64-image payload larger than 2 MB is
rejected with a 413 before the upstream provider is ever called. The
non-strict router buffers manually with an unlimited `to_bytes` call, which
is why this never surfaced before strict mode was enabled.

There was also no way to configure a limit: `AppState` had no body-limit
option.

## Changes

- Add `body_limit: usize` to `AppState`, defaulting to the new
  `DEFAULT_BODY_LIMIT` constant (32 MB), with a `with_body_limit(usize)`
  builder method.
- `build_strict_router` now applies `DefaultBodyLimit::max(state.body_limit)`
  so the `Json` extractors respect the configured limit instead of Axum's
  2 MB default.
- `build_router` (non-strict) applies the same layer, and
  `target_message_handler` now buffers the body with `state.body_limit`
  instead of `usize::MAX`. When the limit is exceeded it returns a new
  OpenAI-style 413 error (`payload_too_large`, message includes the limit)
  instead of an opaque 500.

## Behavior change for non-strict mode

The non-strict router previously buffered request bodies with no limit at
all. It now defaults to 32 MB. Callers that need the old behavior can pass
`usize::MAX` to `with_body_limit`. Strict mode only gets looser (2 MB up to
32 MB), never stricter.

## Tests

- `test_strict_router_accepts_body_over_axum_2mb_default`: regression test,
  a 3 MB chat completions body now returns 200 instead of 413.
- `test_strict_router_accepts_base64_image_over_axum_2mb_default`: the prod
  failure mode, a vision request with a roughly 3 MB base64 data URL in an
  `image_url` content part returns 200.
- `test_strict_router_rejects_body_over_configured_limit`: a body over a
  custom `with_body_limit` value returns 413.
- `test_non_strict_router_rejects_body_over_configured_limit`: non-strict
  router returns a 413 with the OpenAI error envelope and the limit in the
  message.

All 407 existing tests plus doctests pass; clippy and fmt are clean (the
remaining fmt diffs exist on main too).

## Follow-ups (not in this PR)

- dwctl needs to pass `limits.requests.max_body_size` via
  `with_body_limit` when building the onwards router (separate PR, depends
  on this releasing).
- Strict-mode 413 rejections still use Axum's plain-text rejection body
  rather than the OpenAI error envelope; converting those is a separate
  change touching all `Json` extractor rejections.
