### PR TITLE
feat: cached-input-classification seam (dormant CacheClassifier + usage adapter)

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,46 +1,46 @@
-//! Cached-input-pricing seam (the onwards ↔ dwctl boundary).
+//! Cached-input-classification seam (the onwards ↔ dwctl boundary).
 //!
 //! This module defines the *dormant plumbing* for Anthropic-style cached input
-//! pricing. onwards owns the abstraction (the [`CachePricer`] trait, the
-//! neutral [`CacheStats`] result, and the [`NoopCachePricer`] default); the
+//! classification. onwards owns the abstraction (the [`CacheClassifier`] trait, the
+//! neutral [`CacheStats`] result, and the [`NoopCacheClassifier`] default); the
 //! real classification logic — index lookup, prefix hashing, tokenizer calls —
 //! is implemented downstream in dwctl and injected at startup via
-//! [`crate::AppState::with_cache_pricer`]. This is dependency inversion: the
+//! [`crate::AppState::with_cache_classifier`]. This is dependency inversion: the
 //! compile-time dependency points one way (dwctl → onwards), the runtime call
 //! goes the other way through the trait object, so there is no crate cycle.
 //!
 //! ## Dormant by default
 //!
-//! When no pricer is wired (the default), onwards behaviour is byte-identical
+//! When no classifier is wired (the default), onwards behaviour is byte-identical
 //! to today: no request forking, no `cache_control` stripping, and no usage
 //! injection. The entire cache path in [`crate::handlers`] is gated on
-//! `Some(pricer)`. A standalone onwards therefore sees zero observable change.
+//! `Some(classifier)`. A standalone onwards therefore sees zero observable change.
 //!
-//! ## The active path (when a pricer is wired)
+//! ## The active path (when a classifier is wired)
 //!
 //! On each request onwards *forks*: it forwards to the upstream model and, in
-//! parallel, calls [`CachePricer::classify`] under a deadline. The neutral
+//! parallel, calls [`CacheClassifier::classify`] under a deadline. The neutral
 //! [`CacheStats`] split is then injected into the response `usage` object by
-//! the OpenAI shaping helpers in [`crate::cache_usage`]. The no-op pricer
-//! returns all-zero stats, so even with the pricer wired the injected fields
+//! the OpenAI shaping helpers in [`crate::cache_usage`]. The no-op classifier
+//! returns all-zero stats, so even with the classifier wired the injected fields
 //! are zero and downstream billing is unaffected.
 //!
-//! See `input-token-cache-pricing.md` §5.3, §6.1, §6.2, §6.3 for the design.
+//! See `input-token-cache-classification.md` §5.3, §6.1, §6.2, §6.3 for the design.
 
 use async_trait::async_trait;
 use std::time::Duration;
 
 /// Default deadline for the parallel classify branch.
 ///
-/// On a real pricer this bounds how long the response join will wait for the
+/// On a real classifier this bounds how long the response join will wait for the
 /// classification before falling back to all-zero stats (best-effort, billed
-/// as un-cached). The no-op pricer returns instantly so this is never hit in
-/// practice, but the deadline structure is built so a real pricer slots in.
+/// as un-cached). The no-op classifier returns instantly so this is never hit in
+/// practice, but the deadline structure is built so a real classifier slots in.
 pub const DEFAULT_CLASSIFY_DEADLINE: Duration = Duration::from_secs(5);
 
-/// The input handed to a [`CachePricer`] for classification.
+/// The input handed to a [`CacheClassifier`] for classification.
 ///
-/// Carries what a real pricer needs to compute the read/write split: the
+/// Carries what a real classifier needs to compute the read/write split: the
 /// **virtual** model string (the user-facing alias / `OriginalModel`, *not*
 /// the rewritten underlying `model_name` — see `handlers.rs`), and the request
 /// body it must parse for `cache_control` markers. Kept minimal but real.
@@ -50,12 +50,12 @@ pub struct ClassifyInput {
     /// This is the `OriginalModel` retained in request extensions, before
     /// onwards rewrites the outbound `model` field to the underlying name.
     pub virtual_model: String,
-    /// The request path (e.g. `/v1/chat/completions`). Lets a pricer scope
+    /// The request path (e.g. `/v1/chat/completions`). Lets a classifier scope
     /// itself to the endpoints it understands and ignore the rest.
     pub path: String,
-    /// The raw request body bytes (the messages / content blocks the pricer
+    /// The raw request body bytes (the messages / content blocks the classifier
     /// parses for `cache_control` markers). This is the *pre-strip* body, so
-    /// the markers are still present for the pricer to read.
+    /// the markers are still present for the classifier to read.
     pub body: bytes::Bytes,
 }
 
@@ -64,7 +64,7 @@ pub struct ClassifyInput {
 /// This is deliberately *not* OpenAI- or Anthropic-shaped — it is the neutral
 /// representation that a per-endpoint module (the `openai` shaping today, an
 /// `anthropic` shaping later) projects into the wire `usage` object. All
-/// counts default to zero, which is exactly what [`NoopCachePricer`] returns.
+/// counts default to zero, which is exactly what [`NoopCacheClassifier`] returns.
 ///
 /// `read` is the number of cached input tokens read back (charged at the
 /// discounted rate); `creation_*` are the new tokens written to the cache,
@@ -90,7 +90,7 @@ impl CacheStats {
     }
 
     /// True when every count is zero — the dormant / no-op case. Used to skip
-    /// usage injection entirely so a no-op pricer leaves the response shape
+    /// usage injection entirely so a no-op classifier leaves the response shape
     /// untouched beyond what was already there.
     pub fn is_zero(&self) -> bool {
         *self == CacheStats::default()
@@ -103,25 +103,25 @@ impl CacheStats {
 /// imports the implementor.
 ///
 /// `classify` must be cheap relative to the model call — it runs concurrently
-/// with generation and is joined under a deadline, so a slow or failing pricer
+/// with generation and is joined under a deadline, so a slow or failing classifier
 /// degrades to all-zero stats rather than delaying the response.
 #[async_trait]
-pub trait CachePricer: Send + Sync {
+pub trait CacheClassifier: Send + Sync {
     /// Classify a request into a neutral [`CacheStats`] split.
     async fn classify(&self, req: &ClassifyInput) -> CacheStats;
 }
 
-/// The default no-op pricer: always returns all-zero [`CacheStats`].
+/// The default no-op classifier: always returns all-zero [`CacheStats`].
 ///
 /// This is what makes onwards runnable standalone with the cache path "on" but
 /// effectively invisible — the injected `usage` cache fields are all zero, so
-/// downstream billing sees zeros and is unaffected. It is also the pricer
+/// downstream billing sees zeros and is unaffected. It is also the classifier
 /// dwctl wires for local end-to-end validation of the spine.
 #[derive(Debug, Clone, Copy, Default)]
-pub struct NoopCachePricer;
+pub struct NoopCacheClassifier;
 
 #[async_trait]
-impl CachePricer for NoopCachePricer {
+impl CacheClassifier for NoopCacheClassifier {
     async fn classify(&self, _req: &ClassifyInput) -> CacheStats {
         CacheStats::default()
     }
@@ -155,8 +155,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn noop_pricer_returns_zero_stats() {
-        let pricer = NoopCachePricer;
+    async fn noop_classifier_returns_zero_stats() {
+        let classifier = NoopCacheClassifier;
         let input = ClassifyInput {
             virtual_model: "my-virtual-model".to_string(),
             path: "/v1/chat/completions".to_string(),
@@ -164,7 +164,7 @@ mod tests {
                 br#"{"model":"my-virtual-model","messages":[{"role":"user","content":"hi"}]}"#,
             ),
         };
-        let stats = pricer.classify(&input).await;
+        let stats = classifier.classify(&input).await;
         assert_eq!(stats, CacheStats::default());
         assert!(stats.is_zero());
     }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -25,7 +25,11 @@
 //! returns all-zero stats, so even with the classifier wired the injected fields
 //! are zero and downstream billing is unaffected.
 //!
-//! See `input-token-cache-classification.md` §5.3, §6.1, §6.2, §6.3 for the design.
+//! The seam lives in `target_message_handler`, which both the regular and the strict
+//! routers route through — so strict-mode requests get the same treatment
+//! automatically, with no extra wiring.
+//!
+//! See `input-token-cache-pricing.md` §5.3, §6.1, §6.2, §6.3 for the design.
 
 use async_trait::async_trait;
 use std::time::Duration;

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,171 @@
+//! Cached-input-pricing seam (the onwards ↔ dwctl boundary).
+//!
+//! This module defines the *dormant plumbing* for Anthropic-style cached input
+//! pricing. onwards owns the abstraction (the [`CachePricer`] trait, the
+//! neutral [`CacheStats`] result, and the [`NoopCachePricer`] default); the
+//! real classification logic — index lookup, prefix hashing, tokenizer calls —
+//! is implemented downstream in dwctl and injected at startup via
+//! [`crate::AppState::with_cache_pricer`]. This is dependency inversion: the
+//! compile-time dependency points one way (dwctl → onwards), the runtime call
+//! goes the other way through the trait object, so there is no crate cycle.
+//!
+//! ## Dormant by default
+//!
+//! When no pricer is wired (the default), onwards behaviour is byte-identical
+//! to today: no request forking, no `cache_control` stripping, and no usage
+//! injection. The entire cache path in [`crate::handlers`] is gated on
+//! `Some(pricer)`. A standalone onwards therefore sees zero observable change.
+//!
+//! ## The active path (when a pricer is wired)
+//!
+//! On each request onwards *forks*: it forwards to the upstream model and, in
+//! parallel, calls [`CachePricer::classify`] under a deadline. The neutral
+//! [`CacheStats`] split is then injected into the response `usage` object by
+//! the OpenAI shaping helpers in [`crate::cache_usage`]. The no-op pricer
+//! returns all-zero stats, so even with the pricer wired the injected fields
+//! are zero and downstream billing is unaffected.
+//!
+//! See `input-token-cache-pricing.md` §5.3, §6.1, §6.2, §6.3 for the design.
+
+use async_trait::async_trait;
+use std::time::Duration;
+
+/// Default deadline for the parallel classify branch.
+///
+/// On a real pricer this bounds how long the response join will wait for the
+/// classification before falling back to all-zero stats (best-effort, billed
+/// as un-cached). The no-op pricer returns instantly so this is never hit in
+/// practice, but the deadline structure is built so a real pricer slots in.
+pub const DEFAULT_CLASSIFY_DEADLINE: Duration = Duration::from_secs(5);
+
+/// The input handed to a [`CachePricer`] for classification.
+///
+/// Carries what a real pricer needs to compute the read/write split: the
+/// **virtual** model string (the user-facing alias / `OriginalModel`, *not*
+/// the rewritten underlying `model_name` — see `handlers.rs`), and the request
+/// body it must parse for `cache_control` markers. Kept minimal but real.
+#[derive(Debug, Clone)]
+pub struct ClassifyInput {
+    /// The virtual model string the client sent (the cache key dimension).
+    /// This is the `OriginalModel` retained in request extensions, before
+    /// onwards rewrites the outbound `model` field to the underlying name.
+    pub virtual_model: String,
+    /// The request path (e.g. `/v1/chat/completions`). Lets a pricer scope
+    /// itself to the endpoints it understands and ignore the rest.
+    pub path: String,
+    /// The raw request body bytes (the messages / content blocks the pricer
+    /// parses for `cache_control` markers). This is the *pre-strip* body, so
+    /// the markers are still present for the pricer to read.
+    pub body: bytes::Bytes,
+}
+
+/// The paradigm-neutral result of classification: the read/write token split.
+///
+/// This is deliberately *not* OpenAI- or Anthropic-shaped — it is the neutral
+/// representation that a per-endpoint module (the `openai` shaping today, an
+/// `anthropic` shaping later) projects into the wire `usage` object. All
+/// counts default to zero, which is exactly what [`NoopCachePricer`] returns.
+///
+/// `read` is the number of cached input tokens read back (charged at the
+/// discounted rate); `creation_*` are the new tokens written to the cache,
+/// split per TTL tier because their write premiums differ.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct CacheStats {
+    /// Cached input tokens read back from a prior write (the discounted span).
+    pub read: u64,
+    /// New tokens written under the 5-minute TTL tier.
+    pub creation_5m: u64,
+    /// New tokens written under the 1-hour TTL tier.
+    pub creation_1h: u64,
+    /// New tokens written under the 24-hour TTL tier.
+    pub creation_24h: u64,
+}
+
+impl CacheStats {
+    /// Total tokens written to the cache across all TTL tiers.
+    pub fn creation_total(&self) -> u64 {
+        self.creation_5m
+            .saturating_add(self.creation_1h)
+            .saturating_add(self.creation_24h)
+    }
+
+    /// True when every count is zero — the dormant / no-op case. Used to skip
+    /// usage injection entirely so a no-op pricer leaves the response shape
+    /// untouched beyond what was already there.
+    pub fn is_zero(&self) -> bool {
+        *self == CacheStats::default()
+    }
+}
+
+/// The abstraction onwards owns: given a request, return the read/write token
+/// split. Implemented by dwctl (with the real index/tokenizer logic) and
+/// injected at startup; onwards holds it as a trait object and never names or
+/// imports the implementor.
+///
+/// `classify` must be cheap relative to the model call — it runs concurrently
+/// with generation and is joined under a deadline, so a slow or failing pricer
+/// degrades to all-zero stats rather than delaying the response.
+#[async_trait]
+pub trait CachePricer: Send + Sync {
+    /// Classify a request into a neutral [`CacheStats`] split.
+    async fn classify(&self, req: &ClassifyInput) -> CacheStats;
+}
+
+/// The default no-op pricer: always returns all-zero [`CacheStats`].
+///
+/// This is what makes onwards runnable standalone with the cache path "on" but
+/// effectively invisible — the injected `usage` cache fields are all zero, so
+/// downstream billing sees zeros and is unaffected. It is also the pricer
+/// dwctl wires for local end-to-end validation of the spine.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NoopCachePricer;
+
+#[async_trait]
+impl CachePricer for NoopCachePricer {
+    async fn classify(&self, _req: &ClassifyInput) -> CacheStats {
+        CacheStats::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_stats_default_is_all_zero() {
+        let s = CacheStats::default();
+        assert_eq!(s.read, 0);
+        assert_eq!(s.creation_5m, 0);
+        assert_eq!(s.creation_1h, 0);
+        assert_eq!(s.creation_24h, 0);
+        assert_eq!(s.creation_total(), 0);
+        assert!(s.is_zero());
+    }
+
+    #[test]
+    fn creation_total_sums_tiers() {
+        let s = CacheStats {
+            read: 100,
+            creation_5m: 1,
+            creation_1h: 2,
+            creation_24h: 3,
+        };
+        assert_eq!(s.creation_total(), 6);
+        assert!(!s.is_zero());
+    }
+
+    #[tokio::test]
+    async fn noop_pricer_returns_zero_stats() {
+        let pricer = NoopCachePricer;
+        let input = ClassifyInput {
+            virtual_model: "my-virtual-model".to_string(),
+            path: "/v1/chat/completions".to_string(),
+            body: bytes::Bytes::from_static(
+                br#"{"model":"my-virtual-model","messages":[{"role":"user","content":"hi"}]}"#,
+            ),
+        };
+        let stats = pricer.classify(&input).await;
+        assert_eq!(stats, CacheStats::default());
+        assert!(stats.is_zero());
+    }
+}

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -89,9 +89,13 @@ impl CacheStats {
             .saturating_add(self.creation_24h)
     }
 
-    /// True when every count is zero — the dormant / no-op case. Used to skip
-    /// usage injection entirely so a no-op classifier leaves the response shape
-    /// untouched beyond what was already there.
+    /// True when every count is zero (the no-op / "no cached tokens" case).
+    ///
+    /// A convenience predicate only. The injection path deliberately still writes
+    /// the zeroed cache fields when a classifier is wired — the usage shape is kept
+    /// consistent with Anthropic/OpenAI, which always include the cache fields when
+    /// caching is active (see [`crate::cache_usage`]). The dormant case (no
+    /// classifier wired) is what leaves the response untouched, not a zero result.
     pub fn is_zero(&self) -> bool {
         *self == CacheStats::default()
     }

--- a/src/cache_usage.rs
+++ b/src/cache_usage.rs
@@ -1,0 +1,411 @@
+//! OpenAI-shaped request sanitisation and response usage injection for the
+//! cached-input-pricing seam.
+//!
+//! This is the §4 "adapter at the edge" for OpenAI-compatible endpoints,
+//! realised as onwards helpers. It does two jobs, both gated on a wired pricer
+//! in [`crate::handlers`]:
+//!
+//! 1. **Outbound request sanitisation** ([`strip_cache_control`]): recursively
+//!    remove every `cache_control` field from the request body, and ensure
+//!    `stream_options.include_usage = true` so a streaming response carries a
+//!    terminal usage frame to edit. Stripping is the safe first-pass policy:
+//!    upstreams vary and may reject unknown fields, and the marker is consumed
+//!    here as a billing signal, not forwarded.
+//!
+//! 2. **Response usage injection** ([`inject_into_usage_json`] /
+//!    [`inject_into_sse_body`]): splice the neutral [`CacheStats`] into the
+//!    OpenAI `usage` object per §5.2 — `prompt_tokens_details.cached_tokens`
+//!    plus the doubleword extension fields. Non-streaming edits the JSON body;
+//!    streaming edits *only* the terminal usage frame before `[DONE]`, leaving
+//!    every delta chunk untouched and never buffering the whole stream.
+//!
+//! With the no-op pricer every injected field is zero.
+
+use crate::cache::CacheStats;
+use axum::response::Response;
+use bytes::Bytes;
+use http_body_util::BodyExt;
+use serde_json::Value;
+use tracing::error;
+
+/// Recursively remove all `cache_control` fields from a JSON value.
+///
+/// Walks objects and arrays; at every object level it drops the
+/// `cache_control` key (wherever a marker can ride — top-level, message,
+/// content block) and recurses into the remaining values. Returns true if any
+/// marker was removed.
+fn remove_cache_control(value: &mut Value) -> bool {
+    let mut removed = false;
+    match value {
+        Value::Object(map) => {
+            if map.remove("cache_control").is_some() {
+                removed = true;
+            }
+            for v in map.values_mut() {
+                removed |= remove_cache_control(v);
+            }
+        }
+        Value::Array(items) => {
+            for v in items.iter_mut() {
+                removed |= remove_cache_control(v);
+            }
+        }
+        _ => {}
+    }
+    removed
+}
+
+/// Sanitise an outbound request body for the cache path: strip every
+/// `cache_control` marker (recursively) and, for streaming requests, ensure
+/// `stream_options.include_usage = true` so a terminal usage frame exists to
+/// inject into.
+///
+/// Returns `Some(bytes)` with the rewritten body when anything changed, or
+/// `None` to leave the original body untouched (so the caller can cheaply
+/// skip re-serialisation when there was no marker and usage was already set).
+///
+/// This is independent of the pricer result and runs on the request pass, so
+/// it never reintroduces blocking on the model call.
+pub fn strip_cache_control(body: &[u8]) -> Option<Bytes> {
+    let mut json: Value = serde_json::from_slice(body).ok()?;
+
+    let stripped = remove_cache_control(&mut json);
+
+    // Ensure include_usage for streaming requests so the terminal usage frame
+    // (the thing we inject into) is emitted. Mirror stream_usage.rs semantics:
+    // only touch streaming requests, and only the include_usage flag.
+    let mut usage_set = false;
+    if let Some(obj) = json.as_object_mut() {
+        let is_streaming = obj.get("stream").and_then(Value::as_bool) == Some(true);
+        if is_streaming {
+            let opts = obj
+                .entry("stream_options")
+                .or_insert_with(|| serde_json::json!({}));
+            if let Some(opts_obj) = opts.as_object_mut() {
+                let already = opts_obj.get("include_usage").and_then(Value::as_bool) == Some(true);
+                if !already {
+                    opts_obj.insert("include_usage".to_string(), serde_json::json!(true));
+                    usage_set = true;
+                }
+            }
+        }
+    }
+
+    if stripped || usage_set {
+        serde_json::to_vec(&json).ok().map(Bytes::from)
+    } else {
+        None
+    }
+}
+
+/// Splice the OpenAI-shaped cache fields (per §5.2) into a `usage` JSON object
+/// in place. `prompt_tokens` is left as the full input count (OpenAI
+/// semantics) — only the cache breakdown is added:
+///
+/// - `prompt_tokens_details.cached_tokens` = read tokens
+/// - `cache_read_input_tokens` (extension) = read tokens
+/// - `cache_creation_input_tokens` (extension) = total creation tokens
+/// - `cache_creation.{ephemeral_5m,1h,24h}_input_tokens` (extension) = per-tier
+fn splice_cache_fields(usage: &mut serde_json::Map<String, Value>, stats: &CacheStats) {
+    // prompt_tokens_details.cached_tokens — the stock OpenAI field.
+    let details = usage
+        .entry("prompt_tokens_details")
+        .or_insert_with(|| serde_json::json!({}));
+    if let Some(details_obj) = details.as_object_mut() {
+        details_obj.insert("cached_tokens".to_string(), serde_json::json!(stats.read));
+    }
+
+    // doubleword extension fields (OpenAI clients ignore unknown response fields).
+    usage.insert(
+        "cache_read_input_tokens".to_string(),
+        serde_json::json!(stats.read),
+    );
+    usage.insert(
+        "cache_creation_input_tokens".to_string(),
+        serde_json::json!(stats.creation_total()),
+    );
+    usage.insert(
+        "cache_creation".to_string(),
+        serde_json::json!({
+            "ephemeral_5m_input_tokens": stats.creation_5m,
+            "ephemeral_1h_input_tokens": stats.creation_1h,
+            "ephemeral_24h_input_tokens": stats.creation_24h,
+        }),
+    );
+}
+
+/// Inject the cache stats into a non-streaming chat-completion JSON body.
+///
+/// Returns the rewritten body, or `None` if the body could not be parsed or
+/// has no `usage` object to edit (in which case the caller leaves it
+/// untouched). When `stats.is_zero()` this still injects the zeroed fields so
+/// the response shape is consistent for a wired pricer — callers gate the
+/// whole cache path on `Some(pricer)`, so a dormant onwards never reaches here.
+pub fn inject_into_usage_json(body: &[u8], stats: &CacheStats) -> Option<Bytes> {
+    let mut json: Value = serde_json::from_slice(body).ok()?;
+    let obj = json.as_object_mut()?;
+    let usage = obj.get_mut("usage")?.as_object_mut()?;
+    splice_cache_fields(usage, stats);
+    serde_json::to_vec(&json).ok().map(Bytes::from)
+}
+
+/// Inject the cache stats into the terminal usage frame of an SSE body.
+///
+/// Scans `data:` lines for the chunk that carries a `usage` object (the
+/// terminal frame emitted when `include_usage=true`), edits only that frame,
+/// and leaves every other line — including `[DONE]` and all content deltas —
+/// byte-for-byte unchanged. SSE framing (the `\n\n` delimiters and trailing
+/// newlines) is preserved.
+///
+/// Returns the rewritten body, or `None` if no usage-bearing frame was found
+/// (so the caller forwards the original).
+pub fn inject_into_sse_body(body: &[u8], stats: &CacheStats) -> Option<Bytes> {
+    let body_str = std::str::from_utf8(body).ok()?;
+
+    let mut out = String::with_capacity(body_str.len() + 256);
+    let mut edited = false;
+
+    // Preserve exact line structure: split on '\n' keeping empties, rejoin with
+    // '\n', then restore the trailing-newline count from the input.
+    let mut first = true;
+    for line in body_str.split('\n') {
+        if !first {
+            out.push('\n');
+        }
+        first = false;
+
+        if !edited && let Some(data) = line.strip_prefix("data: ") {
+            let trimmed = data.trim();
+            if trimmed != "[DONE]"
+                && let Ok(mut chunk) = serde_json::from_str::<Value>(trimmed)
+                && let Some(chunk_obj) = chunk.as_object_mut()
+                && let Some(usage) = chunk_obj.get_mut("usage")
+                && let Some(usage_obj) = usage.as_object_mut()
+            {
+                splice_cache_fields(usage_obj, stats);
+                if let Ok(reserialized) = serde_json::to_string(&chunk) {
+                    out.push_str("data: ");
+                    out.push_str(&reserialized);
+                    edited = true;
+                    continue;
+                }
+            }
+        }
+        out.push_str(line);
+    }
+
+    if edited { Some(Bytes::from(out)) } else { None }
+}
+
+/// Inject the cache stats into a chat-completion response, dispatching on
+/// content type:
+///
+/// - **Streaming SSE**: wrap the body stream and edit only the first
+///   usage-bearing chunk as it flows, leaving all other chunks untouched. The
+///   stream is never fully buffered.
+/// - **Non-streaming**: buffer the (already-complete) JSON body, splice the
+///   cache fields into `usage`, and rebuild the body.
+///
+/// If injection finds nothing to edit (e.g. no `usage`), the response is
+/// returned with its body preserved.
+pub async fn inject_cache_stats_into_response(
+    mut response: Response,
+    stats: &CacheStats,
+) -> Response {
+    let is_sse = response
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .map(|v| v.contains("text/event-stream"))
+        .unwrap_or(false);
+
+    if is_sse {
+        use futures_util::StreamExt;
+
+        let stats = *stats;
+        // `edited` flips true after the terminal usage frame is rewritten, so
+        // we only ever touch one frame and skip the JSON parse on every other
+        // chunk. State is moved into the stream closure.
+        let mut edited = false;
+        let body_stream = BodyExt::into_data_stream(std::mem::take(response.body_mut()));
+        let transformed = body_stream.map(move |chunk_result| match chunk_result {
+            Ok(chunk) => {
+                if edited {
+                    return Ok::<_, std::io::Error>(chunk);
+                }
+                match inject_into_sse_body(&chunk, &stats) {
+                    Some(rewritten) => {
+                        edited = true;
+                        Ok(rewritten)
+                    }
+                    None => Ok(chunk),
+                }
+            }
+            Err(e) => Err(std::io::Error::other(e)),
+        });
+
+        *response.body_mut() = axum::body::Body::from_stream(transformed);
+        response
+    } else {
+        // Non-streaming: buffer the complete JSON body and splice.
+        let (mut parts, body) = response.into_parts();
+        let body_bytes = match BodyExt::collect(body).await {
+            Ok(collected) => collected.to_bytes(),
+            Err(e) => {
+                error!("Failed to buffer response body for cache injection: {}", e);
+                // Cannot recover the consumed body; return an empty body. This
+                // path is only reached on a genuine body-read error, which
+                // would have failed the client read anyway.
+                return Response::from_parts(parts, axum::body::Body::empty());
+            }
+        };
+
+        match inject_into_usage_json(&body_bytes, stats) {
+            Some(rewritten) => {
+                let len = rewritten.len();
+                parts.headers.remove(axum::http::header::TRANSFER_ENCODING);
+                parts.headers.insert(
+                    axum::http::header::CONTENT_LENGTH,
+                    axum::http::HeaderValue::from(len),
+                );
+                Response::from_parts(parts, axum::body::Body::from(rewritten))
+            }
+            None => Response::from_parts(parts, axum::body::Body::from(body_bytes)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stats() -> CacheStats {
+        CacheStats {
+            read: 1024,
+            creation_5m: 10,
+            creation_1h: 20,
+            creation_24h: 30,
+        }
+    }
+
+    #[test]
+    fn strip_removes_nested_cache_control() {
+        let body = br#"{
+            "model": "m",
+            "messages": [
+                {"role": "system", "content": [
+                    {"type": "text", "text": "sys", "cache_control": {"type": "ephemeral", "ttl": "1h"}}
+                ]},
+                {"role": "user", "content": "hi", "cache_control": {"type": "ephemeral"}}
+            ],
+            "cache_control": {"type": "ephemeral"}
+        }"#;
+        let out = strip_cache_control(body).expect("should rewrite");
+        let v: Value = serde_json::from_slice(&out).unwrap();
+        assert!(v.get("cache_control").is_none());
+        let msgs = v["messages"].as_array().unwrap();
+        assert!(msgs[1].get("cache_control").is_none());
+        let content = msgs[0]["content"].as_array().unwrap();
+        assert!(content[0].get("cache_control").is_none());
+        // body content otherwise intact
+        assert_eq!(content[0]["text"], "sys");
+    }
+
+    #[test]
+    fn strip_returns_none_when_nothing_to_do() {
+        let body = br#"{"model":"m","messages":[{"role":"user","content":"hi"}]}"#;
+        assert!(strip_cache_control(body).is_none());
+    }
+
+    #[test]
+    fn strip_sets_include_usage_for_streaming() {
+        let body = br#"{"model":"m","stream":true,"messages":[{"role":"user","content":"hi"}]}"#;
+        let out = strip_cache_control(body).expect("should rewrite (include_usage)");
+        let v: Value = serde_json::from_slice(&out).unwrap();
+        assert_eq!(v["stream_options"]["include_usage"], true);
+    }
+
+    #[test]
+    fn strip_leaves_non_streaming_usage_alone() {
+        // no cache_control, not streaming → nothing to do
+        let body = br#"{"model":"m","stream":false,"messages":[{"role":"user","content":"hi"}]}"#;
+        assert!(strip_cache_control(body).is_none());
+    }
+
+    #[test]
+    fn inject_non_streaming_adds_cache_fields() {
+        let body = br#"{
+            "id":"c1","object":"chat.completion","model":"m",
+            "choices":[],
+            "usage":{"prompt_tokens":1100,"completion_tokens":5,"total_tokens":1105}
+        }"#;
+        let out = inject_into_usage_json(body, &stats()).expect("should inject");
+        let v: Value = serde_json::from_slice(&out).unwrap();
+        let usage = &v["usage"];
+        // prompt_tokens untouched (full input count)
+        assert_eq!(usage["prompt_tokens"], 1100);
+        assert_eq!(usage["prompt_tokens_details"]["cached_tokens"], 1024);
+        assert_eq!(usage["cache_read_input_tokens"], 1024);
+        assert_eq!(usage["cache_creation_input_tokens"], 60);
+        assert_eq!(usage["cache_creation"]["ephemeral_5m_input_tokens"], 10);
+        assert_eq!(usage["cache_creation"]["ephemeral_1h_input_tokens"], 20);
+        assert_eq!(usage["cache_creation"]["ephemeral_24h_input_tokens"], 30);
+    }
+
+    #[test]
+    fn inject_non_streaming_zero_stats_injects_zeros() {
+        let body = br#"{"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}"#;
+        let out = inject_into_usage_json(body, &CacheStats::default()).expect("should inject");
+        let v: Value = serde_json::from_slice(&out).unwrap();
+        assert_eq!(v["usage"]["prompt_tokens_details"]["cached_tokens"], 0);
+        assert_eq!(v["usage"]["cache_read_input_tokens"], 0);
+        assert_eq!(v["usage"]["cache_creation_input_tokens"], 0);
+    }
+
+    #[test]
+    fn inject_non_streaming_none_when_no_usage() {
+        let body = br#"{"id":"c1","choices":[]}"#;
+        assert!(inject_into_usage_json(body, &stats()).is_none());
+    }
+
+    #[test]
+    fn inject_sse_edits_only_terminal_usage_frame() {
+        // A delta chunk (no usage), then a terminal usage frame, then [DONE].
+        let body = "data: {\"id\":\"c1\",\"object\":\"chat.completion.chunk\",\"model\":\"m\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"}}]}\n\ndata: {\"id\":\"c1\",\"object\":\"chat.completion.chunk\",\"model\":\"m\",\"choices\":[],\"usage\":{\"prompt_tokens\":1100,\"completion_tokens\":5,\"total_tokens\":1105}}\n\ndata: [DONE]\n\n";
+        let out = inject_into_sse_body(body.as_bytes(), &stats()).expect("should inject");
+        let out_str = std::str::from_utf8(&out).unwrap();
+
+        // Delta chunk content untouched.
+        assert!(out_str.contains("\"delta\":{\"content\":\"hi\"}"));
+        // Usage frame got the cache fields.
+        assert!(out_str.contains("\"cached_tokens\":1024"));
+        assert!(out_str.contains("\"cache_read_input_tokens\":1024"));
+        assert!(out_str.contains("\"cache_creation_input_tokens\":60"));
+        assert!(out_str.contains("\"ephemeral_1h_input_tokens\":20"));
+        // [DONE] preserved.
+        assert!(out_str.contains("data: [DONE]"));
+        // Framing preserved: ends with \n\n.
+        assert!(out_str.ends_with("\n\n"));
+        // The delta chunk should appear before the usage frame (order preserved).
+        let delta_pos = out_str.find("\"content\":\"hi\"").unwrap();
+        let usage_pos = out_str.find("cached_tokens").unwrap();
+        assert!(delta_pos < usage_pos);
+    }
+
+    #[test]
+    fn inject_sse_none_when_no_usage_frame() {
+        let body = "data: {\"id\":\"c1\",\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\ndata: [DONE]\n\n";
+        assert!(inject_into_sse_body(body.as_bytes(), &stats()).is_none());
+    }
+
+    #[test]
+    fn inject_sse_only_edits_first_usage_frame() {
+        // Defensive: a single usage frame is the norm; ensure we stop after the
+        // first edit and don't touch a second (degenerate) usage line.
+        let body = "data: {\"usage\":{\"prompt_tokens\":1}}\n\ndata: {\"usage\":{\"prompt_tokens\":2}}\n\ndata: [DONE]\n\n";
+        let out = inject_into_sse_body(body.as_bytes(), &stats()).expect("should inject");
+        let out_str = std::str::from_utf8(&out).unwrap();
+        // exactly one injected cached_tokens.
+        assert_eq!(out_str.matches("cached_tokens").count(), 1);
+    }
+}

--- a/src/cache_usage.rs
+++ b/src/cache_usage.rs
@@ -283,17 +283,34 @@ pub async fn inject_cache_stats_into_response(
             }
         };
 
+        // In both arms the body has been fully buffered, so any chunked
+        // Transfer-Encoding no longer applies — drop it and set the real
+        // Content-Length so the framing is consistent.
         match inject_into_usage_json(&body_bytes, stats) {
             Some(rewritten) => {
                 let len = rewritten.len();
                 parts.headers.remove(axum::http::header::TRANSFER_ENCODING);
+                // We emit plain (uncompressed) JSON — `inject_into_usage_json` only
+                // succeeds on a body it could parse as JSON — so drop any stale
+                // Content-Encoding that would tell the client to decode it again.
+                parts.headers.remove(axum::http::header::CONTENT_ENCODING);
                 parts.headers.insert(
                     axum::http::header::CONTENT_LENGTH,
                     axum::http::HeaderValue::from(len),
                 );
                 Response::from_parts(parts, axum::body::Body::from(rewritten))
             }
-            None => Response::from_parts(parts, axum::body::Body::from(body_bytes)),
+            None => {
+                // No usage to edit: the bytes are returned untouched, so KEEP any
+                // Content-Encoding (they may still be compressed). Only fix framing.
+                let len = body_bytes.len();
+                parts.headers.remove(axum::http::header::TRANSFER_ENCODING);
+                parts.headers.insert(
+                    axum::http::header::CONTENT_LENGTH,
+                    axum::http::HeaderValue::from(len),
+                );
+                Response::from_parts(parts, axum::body::Body::from(body_bytes))
+            }
         }
     }
 }

--- a/src/cache_usage.rs
+++ b/src/cache_usage.rs
@@ -224,11 +224,16 @@ pub async fn inject_cache_stats_into_response(
 
         let stats = *stats;
         // `edited` flips true after the terminal usage frame is rewritten, so
-        // we only ever touch one frame and skip the JSON parse on every other
-        // chunk. State is moved into the stream closure.
+        // we only ever touch one event and skip the JSON parse on every other.
+        // State is moved into the stream closure.
         let mut edited = false;
         let body_stream = BodyExt::into_data_stream(std::mem::take(response.body_mut()));
-        let transformed = body_stream.map(move |chunk_result| match chunk_result {
+        // Providers can split a single SSE event across body chunks (HTTP framing
+        // is not aligned to `\n\n` event boundaries). SseBufferedStream re-aggregates
+        // so each item we inspect is a complete event — otherwise a split terminal
+        // usage frame would be missed and injection silently skipped.
+        let buffered = crate::sse::SseBufferedStream::new(body_stream);
+        let transformed = buffered.map(move |chunk_result| match chunk_result {
             Ok(chunk) => {
                 if edited {
                     return Ok::<_, std::io::Error>(chunk);
@@ -245,8 +250,26 @@ pub async fn inject_cache_stats_into_response(
         });
 
         *response.body_mut() = axum::body::Body::from_stream(transformed);
+        // The body is now a streaming body of unknown length; drop any stale
+        // Content-Length so it can't mismatch the rewritten stream.
+        response
+            .headers_mut()
+            .remove(axum::http::header::CONTENT_LENGTH);
         response
     } else {
+        // Only JSON bodies can carry a chat-completion `usage`. If Content-Type is
+        // explicitly non-JSON (e.g. a file download), don't buffer it — return as-is
+        // to preserve pass-through performance. Missing/unknown CT falls through to
+        // the JSON attempt (chat completions are JSON).
+        let is_json = response
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .map(|v| v.contains("application/json"))
+            .unwrap_or(true);
+        if !is_json {
+            return response;
+        }
         // Non-streaming: buffer the complete JSON body and splice.
         let (mut parts, body) = response.into_parts();
         let body_bytes = match BodyExt::collect(body).await {
@@ -407,5 +430,37 @@ mod tests {
         let out_str = std::str::from_utf8(&out).unwrap();
         // exactly one injected cached_tokens.
         assert_eq!(out_str.matches("cached_tokens").count(), 1);
+    }
+
+    /// Robustness: providers can split a single SSE event across body chunks.
+    /// `inject_cache_stats_into_response` wraps the stream in `SseBufferedStream`,
+    /// which re-aggregates to complete `\n\n`-delimited events, so the terminal
+    /// usage frame is still found and injected even when split mid-JSON.
+    #[tokio::test]
+    async fn inject_sse_handles_event_split_across_body_chunks() {
+        use futures_util::stream;
+        let chunk1 = "data: {\"id\":\"c1\",\"object\":\"chat.completion.chunk\",\"choices\":[],\"usage\":{\"prompt_to";
+        let chunk2 = "kens\":1100,\"completion_tokens\":5,\"total_tokens\":1105}}\n\n";
+        let chunk3 = "data: [DONE]\n\n";
+        let body = axum::body::Body::from_stream(stream::iter(vec![
+            Ok::<_, std::io::Error>(Bytes::from(chunk1)),
+            Ok(Bytes::from(chunk2)),
+            Ok(Bytes::from(chunk3)),
+        ]));
+        let response = Response::builder()
+            .header("content-type", "text/event-stream")
+            .body(body)
+            .unwrap();
+
+        let out = inject_cache_stats_into_response(response, &stats()).await;
+        let collected = BodyExt::collect(out.into_body()).await.unwrap().to_bytes();
+        let s = std::str::from_utf8(&collected).unwrap();
+        // The split usage frame was re-aggregated and injected.
+        assert!(
+            s.contains("\"cached_tokens\":1024"),
+            "usage frame should be injected across split chunks: {s}"
+        );
+        assert!(s.contains("\"cache_read_input_tokens\":1024"));
+        assert!(s.contains("data: [DONE]"));
     }
 }

--- a/src/cache_usage.rs
+++ b/src/cache_usage.rs
@@ -1,8 +1,8 @@
 //! OpenAI-shaped request sanitisation and response usage injection for the
-//! cached-input-pricing seam.
+//! cache-classification seam.
 //!
 //! This is the §4 "adapter at the edge" for OpenAI-compatible endpoints,
-//! realised as onwards helpers. It does two jobs, both gated on a wired pricer
+//! realised as onwards helpers. It does two jobs, both gated on a wired classifier
 //! in [`crate::handlers`]:
 //!
 //! 1. **Outbound request sanitisation** ([`strip_cache_control`]): recursively
@@ -19,7 +19,7 @@
 //!    streaming edits *only* the terminal usage frame before `[DONE]`, leaving
 //!    every delta chunk untouched and never buffering the whole stream.
 //!
-//! With the no-op pricer every injected field is zero.
+//! With the no-op classifier every injected field is zero.
 
 use crate::cache::CacheStats;
 use axum::response::Response;
@@ -64,7 +64,7 @@ fn remove_cache_control(value: &mut Value) -> bool {
 /// `None` to leave the original body untouched (so the caller can cheaply
 /// skip re-serialisation when there was no marker and usage was already set).
 ///
-/// This is independent of the pricer result and runs on the request pass, so
+/// This is independent of the classifier result and runs on the request pass, so
 /// it never reintroduces blocking on the model call.
 pub fn strip_cache_control(body: &[u8]) -> Option<Bytes> {
     let mut json: Value = serde_json::from_slice(body).ok()?;
@@ -139,8 +139,8 @@ fn splice_cache_fields(usage: &mut serde_json::Map<String, Value>, stats: &Cache
 /// Returns the rewritten body, or `None` if the body could not be parsed or
 /// has no `usage` object to edit (in which case the caller leaves it
 /// untouched). When `stats.is_zero()` this still injects the zeroed fields so
-/// the response shape is consistent for a wired pricer — callers gate the
-/// whole cache path on `Some(pricer)`, so a dormant onwards never reaches here.
+/// the response shape is consistent for a wired classifier — callers gate the
+/// whole cache path on `Some(classifier)`, so a dormant onwards never reaches here.
 pub fn inject_into_usage_json(body: &[u8], stats: &CacheStats) -> Option<Bytes> {
     let mut json: Value = serde_json::from_slice(body).ok()?;
     let obj = json.as_object_mut()?;

--- a/src/cache_usage.rs
+++ b/src/cache_usage.rs
@@ -159,7 +159,14 @@ pub fn inject_into_usage_json(body: &[u8], stats: &CacheStats) -> Option<Bytes> 
 ///
 /// Returns the rewritten body, or `None` if no usage-bearing frame was found
 /// (so the caller forwards the original).
+///
+/// Assumes **uncompressed UTF-8** `text/event-stream` (which is what AI-provider SSE
+/// always is). If the bytes are non-UTF-8 or compressed (`Content-Encoding: gzip`/`br`),
+/// the `from_utf8` parse below returns `None` and injection is skipped — a graceful
+/// no-op: that response just carries no cache fields. We don't decompress here
+/// (streaming gzip would defeat the point of editing one frame in flight).
 pub fn inject_into_sse_body(body: &[u8], stats: &CacheStats) -> Option<Bytes> {
+    // Non-UTF-8 / compressed body → skip injection (graceful no-op; see doc above).
     let body_str = std::str::from_utf8(body).ok()?;
 
     let mut out = String::with_capacity(body_str.len() + 256);

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -298,61 +298,9 @@ pub async fn target_message_handler<T: HttpClient>(
     req.extensions_mut()
         .insert(OriginalModel(model_name.clone()));
 
-    // Cached-input-classification fork (§5.3 / §6.3). Gated on a wired classifier: when
-    // `cache_classifier` is None the whole block is skipped — no fork, no `cache_control`
-    // stripping, and no usage injection — so onwards behaviour is byte-identical to
-    // today (the strip is NOT independent of the gate). When Some:
-    //   - branch B: spawn `classify` on the pre-strip body (markers intact) so
-    //     it runs concurrently with the upstream call (branch A). The deadline
-    //     join happens on the response path.
-    //   - branch A sanitisation: strip ALL `cache_control` markers from the
-    //     outbound body (and ensure include_usage for streaming) before
-    //     forwarding. Independent of the classifier, so it never blocks the model
-    //     call.
-    // Aborts the cache-classify task on drop unless it has been taken. Any
-    // error / early-return path drops the guard and aborts the now-useless
-    // classify — safe because index writes are success-gated, so a half-done
-    // classify has written nothing and cannot pollute the cache. The success
-    // path takes the handle out (so it is NOT aborted) and awaits it under the
-    // deadline; a deadline miss then drops the raw JoinHandle, which *detaches*
-    // (not aborts) so the task finishes and its index write still lands.
-    struct AbortOnDrop(Option<tokio::task::JoinHandle<crate::cache::CacheStats>>);
-    impl AbortOnDrop {
-        fn take(&mut self) -> Option<tokio::task::JoinHandle<crate::cache::CacheStats>> {
-            self.0.take()
-        }
-    }
-    impl Drop for AbortOnDrop {
-        fn drop(&mut self) {
-            if let Some(handle) = self.0.take() {
-                handle.abort();
-            }
-        }
-    }
-
-    let mut cache_classify_handle: AbortOnDrop =
-        AbortOnDrop(if let Some(classifier) = state.cache_classifier.clone() {
-            let path = req.uri().path().to_string();
-            let classify_input = crate::cache::ClassifyInput {
-                // Cache key is the VIRTUAL model (the OriginalModel/alias), not
-                // the underlying name onwards rewrites to downstream.
-                virtual_model: model_name.clone(),
-                path,
-                body: body_bytes.clone(),
-            };
-            let handle =
-                tokio::spawn(async move { classifier.classify(&classify_input).await });
-
-            // Sanitise the outbound request: strip markers + ensure include_usage.
-            if let Some(stripped) = crate::cache_usage::strip_cache_control(&body_bytes) {
-                debug!("Stripped cache_control markers from outbound request");
-                body_bytes = stripped;
-            }
-
-            Some(handle)
-        } else {
-            None
-        });
+    // (The cached-input-classification fork is placed lower down — after auth/routing/
+    // rate-limit/concurrency have all passed, just before dispatch — so invalid,
+    // forbidden, or rate-limited requests never trigger classification work. See §5.3/§6.3.)
 
     trace!("Received request for model: {}", model_name);
     trace!(
@@ -542,6 +490,56 @@ pub async fn target_message_handler<T: HttpClient>(
     // select_iter() uses weighted least connections: picks the provider with the
     // lowest active_connections/weight ratio, skipping providers at their
     // concurrency limit. The returned guard tracks the active connection.
+    // Cached-input-classification fork (§5.3 / §6.3) — placed HERE, after auth/routing/
+    // rate-limit/concurrency have all passed, so invalid / forbidden / rate-limited
+    // requests never trigger (potentially expensive) classification. It still runs
+    // concurrently with the upstream dispatch below, so it adds no latency. Gated on a
+    // wired classifier: with `cache_classifier == None` there is no fork, no
+    // `cache_control` stripping, and no usage injection — byte-identical to today.
+    //
+    // AbortOnDrop aborts the classify task on any error / early-return path (safe: index
+    // writes are success-gated, so a half-done classify has written nothing). The success
+    // path takes the handle out and awaits it under the deadline; a deadline miss detaches
+    // (not aborts) so the task finishes and its index write still lands.
+    struct AbortOnDrop(Option<tokio::task::JoinHandle<crate::cache::CacheStats>>);
+    impl AbortOnDrop {
+        fn take(&mut self) -> Option<tokio::task::JoinHandle<crate::cache::CacheStats>> {
+            self.0.take()
+        }
+    }
+    impl Drop for AbortOnDrop {
+        fn drop(&mut self) {
+            if let Some(handle) = self.0.take() {
+                handle.abort();
+            }
+        }
+    }
+
+    let mut cache_classify_handle: AbortOnDrop =
+        AbortOnDrop(if let Some(classifier) = state.cache_classifier.clone() {
+            let path = req.uri().path().to_string();
+            let classify_input = crate::cache::ClassifyInput {
+                // Cache key is the VIRTUAL model (the OriginalModel/alias), not the
+                // underlying name onwards rewrites to downstream.
+                virtual_model: model_name.clone(),
+                path,
+                body: body_bytes.clone(),
+            };
+            let handle = tokio::spawn(async move { classifier.classify(&classify_input).await });
+
+            // Sanitise the outbound request: strip markers + ensure include_usage.
+            if let Some(stripped) = crate::cache_usage::strip_cache_control(&body_bytes) {
+                debug!(
+                    "Sanitised outbound request for cache path (cache_control stripped and/or include_usage set)"
+                );
+                body_bytes = stripped;
+            }
+
+            Some(handle)
+        } else {
+            None
+        });
+
     let mut any_attempted = false;
     let mut attempt_number: u32 = 0;
     let mut total_backoff_ms: u64 = 0;

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -299,8 +299,9 @@ pub async fn target_message_handler<T: HttpClient>(
         .insert(OriginalModel(model_name.clone()));
 
     // Cached-input-classification fork (§5.3 / §6.3). Gated on a wired classifier: when
-    // `cache_classifier` is None the whole block is skipped and onwards behaviour
-    // is byte-identical to today. When Some:
+    // `cache_classifier` is None the whole block is skipped — no fork, no `cache_control`
+    // stripping, and no usage injection — so onwards behaviour is byte-identical to
+    // today (the strip is NOT independent of the gate). When Some:
     //   - branch B: spawn `classify` on the pre-strip body (markers intact) so
     //     it runs concurrently with the upstream call (branch A). The deadline
     //     join happens on the response path.
@@ -1053,16 +1054,32 @@ pub async fn target_message_handler<T: HttpClient>(
             .insert(ResolvedTrust(resolved_trust));
 
         // Cached-input-classification JOIN (§5.3 / §6.3). Only when a classifier was
-        // wired (handle is Some). Take the handle (consumed once on this
-        // success path), await it under the configured deadline, and inject
-        // the resulting CacheStats into the response usage. On deadline miss
-        // or task failure, fall back to all-zero stats (best-effort,
-        // un-cached). With the no-op classifier the stats are zero.
+        // wired (handle is Some). The classify task has been running in parallel with
+        // the upstream call since the request was forked, so in the normal case it is
+        // already complete here and this await returns immediately. The bounded wait
+        // (cache_classify_deadline) is only hit on a classifier/index/tokenizer outage,
+        // where we fall back to all-zero (best-effort un-cached) stats and let
+        // reconciliation correct any overcharge. With the no-op classifier stats are zero.
+        //
+        // NOTE (streaming): for SSE this await currently precedes returning the body, so
+        // a slow classify (outage only) could delay first-byte by up to the deadline.
+        // The stats are only needed for the terminal usage frame, so deferring the await
+        // into the SSE rewrite stream (resolving lazily at that frame) is a possible
+        // future optimisation — left out for now as classify normally completes well
+        // before time-to-first-token.
         if let Some(handle) = cache_classify_handle.take() {
             let stats = match tokio::time::timeout(state.cache_classify_deadline, handle).await {
                 Ok(Ok(stats)) => stats,
                 Ok(Err(join_err)) => {
-                    error!("Cache classify task failed: {}", join_err);
+                    // Distinguish a real bug (panic) from expected operational
+                    // cancellation, for cleaner log analysis.
+                    if join_err.is_panic() {
+                        error!("Cache classify task panicked: {}", join_err);
+                    } else if join_err.is_cancelled() {
+                        debug!("Cache classify task was cancelled");
+                    } else {
+                        error!("Cache classify task failed: {}", join_err);
+                    }
                     crate::cache::CacheStats::default()
                 }
                 Err(_) => {

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -298,6 +298,61 @@ pub async fn target_message_handler<T: HttpClient>(
     req.extensions_mut()
         .insert(OriginalModel(model_name.clone()));
 
+    // Cached-input-pricing fork (§5.3 / §6.3). Gated on a wired pricer: when
+    // `cache_pricer` is None the whole block is skipped and onwards behaviour
+    // is byte-identical to today. When Some:
+    //   - branch B: spawn `classify` on the pre-strip body (markers intact) so
+    //     it runs concurrently with the upstream call (branch A). The deadline
+    //     join happens on the response path.
+    //   - branch A sanitisation: strip ALL `cache_control` markers from the
+    //     outbound body (and ensure include_usage for streaming) before
+    //     forwarding. Independent of the pricer, so it never blocks the model
+    //     call.
+    // Aborts the cache-classify task on drop unless it has been taken. Any
+    // error / early-return path drops the guard and aborts the now-useless
+    // classify — safe because index writes are success-gated, so a half-done
+    // classify has written nothing and cannot pollute the cache. The success
+    // path takes the handle out (so it is NOT aborted) and awaits it under the
+    // deadline; a deadline miss then drops the raw JoinHandle, which *detaches*
+    // (not aborts) so the task finishes and its index write still lands.
+    struct AbortOnDrop(Option<tokio::task::JoinHandle<crate::cache::CacheStats>>);
+    impl AbortOnDrop {
+        fn take(&mut self) -> Option<tokio::task::JoinHandle<crate::cache::CacheStats>> {
+            self.0.take()
+        }
+    }
+    impl Drop for AbortOnDrop {
+        fn drop(&mut self) {
+            if let Some(handle) = self.0.take() {
+                handle.abort();
+            }
+        }
+    }
+
+    let mut cache_classify_handle: AbortOnDrop =
+        AbortOnDrop(if let Some(pricer) = state.cache_pricer.clone() {
+            let path = req.uri().path().to_string();
+            let classify_input = crate::cache::ClassifyInput {
+                // Cache key is the VIRTUAL model (the OriginalModel/alias), not
+                // the underlying name onwards rewrites to downstream.
+                virtual_model: model_name.clone(),
+                path,
+                body: body_bytes.clone(),
+            };
+            let handle =
+                tokio::spawn(async move { pricer.classify(&classify_input).await });
+
+            // Sanitise the outbound request: strip markers + ensure include_usage.
+            if let Some(stripped) = crate::cache_usage::strip_cache_control(&body_bytes) {
+                debug!("Stripped cache_control markers from outbound request");
+                body_bytes = stripped;
+            }
+
+            Some(handle)
+        } else {
+            None
+        });
+
     trace!("Received request for model: {}", model_name);
     trace!(
         "Available targets: {:?}",
@@ -996,6 +1051,28 @@ pub async fn target_message_handler<T: HttpClient>(
         response
             .extensions_mut()
             .insert(ResolvedTrust(resolved_trust));
+
+        // Cached-input-pricing JOIN (§5.3 / §6.3). Only when a pricer was
+        // wired (handle is Some). Take the handle (consumed once on this
+        // success path), await it under the configured deadline, and inject
+        // the resulting CacheStats into the response usage. On deadline miss
+        // or task failure, fall back to all-zero stats (best-effort,
+        // un-cached). With the no-op pricer the stats are zero.
+        if let Some(handle) = cache_classify_handle.take() {
+            let stats = match tokio::time::timeout(state.cache_classify_deadline, handle).await {
+                Ok(Ok(stats)) => stats,
+                Ok(Err(join_err)) => {
+                    error!("Cache classify task failed: {}", join_err);
+                    crate::cache::CacheStats::default()
+                }
+                Err(_) => {
+                    debug!("Cache classify deadline missed, injecting zero cache stats");
+                    crate::cache::CacheStats::default()
+                }
+            };
+            response =
+                crate::cache_usage::inject_cache_stats_into_response(response, &stats).await;
+        }
 
         // Attach the connection guard and inflight guard to the response body so both
         // are decremented when the body stream completes, not when the handler returns.
@@ -1872,6 +1949,8 @@ mod tests {
             tool_executor: std::sync::Arc::new(crate::NoOpToolExecutor),
             response_store: std::sync::Arc::new(crate::NoOpResponseStore),
             body_limit: crate::DEFAULT_BODY_LIMIT,
+            cache_pricer: None,
+            cache_classify_deadline: crate::cache::DEFAULT_CLASSIFY_DEADLINE,
         };
 
         // Create a simple POST request
@@ -1990,16 +2069,30 @@ mod tests {
         // When propagation is disabled for an upstream, an inbound trace
         // context (e.g. from the caller) must not be forwarded.
         let mut headers = HeaderMap::new();
-        headers.insert("traceparent", "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01".parse().unwrap());
+        headers.insert(
+            "traceparent",
+            "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+                .parse()
+                .unwrap(),
+        );
         headers.insert("tracestate", "vendor=value".parse().unwrap());
         headers.insert("content-type", "application/json".parse().unwrap());
 
         withhold_trace_context(&mut headers);
 
-        assert!(!headers.contains_key("traceparent"), "traceparent must be stripped");
-        assert!(!headers.contains_key("tracestate"), "tracestate must be stripped");
+        assert!(
+            !headers.contains_key("traceparent"),
+            "traceparent must be stripped"
+        );
+        assert!(
+            !headers.contains_key("tracestate"),
+            "tracestate must be stripped"
+        );
         // Unrelated headers are left untouched.
-        assert!(headers.contains_key("content-type"), "non-trace headers must be preserved");
+        assert!(
+            headers.contains_key("content-type"),
+            "non-trace headers must be preserved"
+        );
     }
 
     #[test]

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -298,15 +298,15 @@ pub async fn target_message_handler<T: HttpClient>(
     req.extensions_mut()
         .insert(OriginalModel(model_name.clone()));
 
-    // Cached-input-pricing fork (§5.3 / §6.3). Gated on a wired pricer: when
-    // `cache_pricer` is None the whole block is skipped and onwards behaviour
+    // Cached-input-classification fork (§5.3 / §6.3). Gated on a wired classifier: when
+    // `cache_classifier` is None the whole block is skipped and onwards behaviour
     // is byte-identical to today. When Some:
     //   - branch B: spawn `classify` on the pre-strip body (markers intact) so
     //     it runs concurrently with the upstream call (branch A). The deadline
     //     join happens on the response path.
     //   - branch A sanitisation: strip ALL `cache_control` markers from the
     //     outbound body (and ensure include_usage for streaming) before
-    //     forwarding. Independent of the pricer, so it never blocks the model
+    //     forwarding. Independent of the classifier, so it never blocks the model
     //     call.
     // Aborts the cache-classify task on drop unless it has been taken. Any
     // error / early-return path drops the guard and aborts the now-useless
@@ -330,7 +330,7 @@ pub async fn target_message_handler<T: HttpClient>(
     }
 
     let mut cache_classify_handle: AbortOnDrop =
-        AbortOnDrop(if let Some(pricer) = state.cache_pricer.clone() {
+        AbortOnDrop(if let Some(classifier) = state.cache_classifier.clone() {
             let path = req.uri().path().to_string();
             let classify_input = crate::cache::ClassifyInput {
                 // Cache key is the VIRTUAL model (the OriginalModel/alias), not
@@ -340,7 +340,7 @@ pub async fn target_message_handler<T: HttpClient>(
                 body: body_bytes.clone(),
             };
             let handle =
-                tokio::spawn(async move { pricer.classify(&classify_input).await });
+                tokio::spawn(async move { classifier.classify(&classify_input).await });
 
             // Sanitise the outbound request: strip markers + ensure include_usage.
             if let Some(stripped) = crate::cache_usage::strip_cache_control(&body_bytes) {
@@ -1052,12 +1052,12 @@ pub async fn target_message_handler<T: HttpClient>(
             .extensions_mut()
             .insert(ResolvedTrust(resolved_trust));
 
-        // Cached-input-pricing JOIN (§5.3 / §6.3). Only when a pricer was
+        // Cached-input-classification JOIN (§5.3 / §6.3). Only when a classifier was
         // wired (handle is Some). Take the handle (consumed once on this
         // success path), await it under the configured deadline, and inject
         // the resulting CacheStats into the response usage. On deadline miss
         // or task failure, fall back to all-zero stats (best-effort,
-        // un-cached). With the no-op pricer the stats are zero.
+        // un-cached). With the no-op classifier the stats are zero.
         if let Some(handle) = cache_classify_handle.take() {
             let stats = match tokio::time::timeout(state.cache_classify_deadline, handle).await {
                 Ok(Ok(stats)) => stats,
@@ -1949,7 +1949,7 @@ mod tests {
             tool_executor: std::sync::Arc::new(crate::NoOpToolExecutor),
             response_store: std::sync::Arc::new(crate::NoOpResponseStore),
             body_limit: crate::DEFAULT_BODY_LIMIT,
-            cache_pricer: None,
+            cache_classifier: None,
             cache_classify_deadline: crate::cache::DEFAULT_CLASSIFY_DEADLINE,
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ pub mod telemetry;
 pub mod traits;
 
 pub use cache::{
-    CachePricer, CacheStats, ClassifyInput, DEFAULT_CLASSIFY_DEADLINE, NoopCachePricer,
+    CacheClassifier, CacheStats, ClassifyInput, DEFAULT_CLASSIFY_DEADLINE, NoopCacheClassifier,
 };
 use client::{HttpClient, HyperClient};
 use handlers::{models as models_handler, target_message_handler};
@@ -236,21 +236,21 @@ pub struct AppState<T: HttpClient> {
     /// `DefaultBodyLimit`, which rejects large (e.g. long-context or base64
     /// image) payloads with a 413. Defaults to [`DEFAULT_BODY_LIMIT`].
     pub body_limit: usize,
-    /// Optional cached-input-pricing hook (the onwards ↔ dwctl seam, §6.2).
+    /// Optional cached-input-classification hook (the onwards ↔ dwctl seam, §6.2).
     ///
     /// Defaults to `None`, in which case the entire cache path is dormant and
     /// onwards behaviour is byte-identical to today (no fork, no
     /// `cache_control` stripping, no usage injection). When set via
-    /// [`AppState::with_cache_pricer`], onwards forks each request to the
-    /// pricer in parallel with the upstream call and injects the resulting
+    /// [`AppState::with_cache_classifier`], onwards forks each request to the
+    /// classifier in parallel with the upstream call and injects the resulting
     /// [`cache::CacheStats`] into the response `usage`. The default
-    /// [`cache::NoopCachePricer`] returns all-zero stats, so even when wired
+    /// [`cache::NoopCacheClassifier`] returns all-zero stats, so even when wired
     /// the injected fields are zero and downstream billing is unaffected.
-    pub cache_pricer: Option<Arc<dyn cache::CachePricer>>,
+    pub cache_classifier: Option<Arc<dyn cache::CacheClassifier>>,
     /// Deadline for the parallel classify branch. The response join waits at
-    /// most this long for [`cache::CachePricer::classify`] before falling back
+    /// most this long for [`cache::CacheClassifier::classify`] before falling back
     /// to all-zero stats (best-effort, billed as un-cached). Only consulted
-    /// when `cache_pricer` is `Some`. Defaults to
+    /// when `cache_classifier` is `Some`. Defaults to
     /// [`cache::DEFAULT_CLASSIFY_DEADLINE`].
     pub cache_classify_deadline: std::time::Duration,
 }
@@ -281,8 +281,11 @@ impl<T: HttpClient> std::fmt::Debug for AppState<T> {
             .field("response_store", &"<dyn ResponseStore>")
             .field("body_limit", &self.body_limit)
             .field(
-                "cache_pricer",
-                &self.cache_pricer.as_ref().map(|_| "<dyn CachePricer>"),
+                "cache_classifier",
+                &self
+                    .cache_classifier
+                    .as_ref()
+                    .map(|_| "<dyn CacheClassifier>"),
             )
             .field("cache_classify_deadline", &self.cache_classify_deadline)
             .finish()
@@ -309,7 +312,7 @@ impl AppState<HyperClient> {
             tool_executor: Arc::new(NoOpToolExecutor),
             response_store: Arc::new(NoOpResponseStore),
             body_limit: DEFAULT_BODY_LIMIT,
-            cache_pricer: None,
+            cache_classifier: None,
             cache_classify_deadline: cache::DEFAULT_CLASSIFY_DEADLINE,
         }
     }
@@ -333,7 +336,7 @@ impl AppState<HyperClient> {
             tool_executor: Arc::new(NoOpToolExecutor),
             response_store: Arc::new(NoOpResponseStore),
             body_limit: DEFAULT_BODY_LIMIT,
-            cache_pricer: None,
+            cache_classifier: None,
             cache_classify_deadline: cache::DEFAULT_CLASSIFY_DEADLINE,
         }
     }
@@ -352,7 +355,7 @@ impl<T: HttpClient> AppState<T> {
             tool_executor: Arc::new(NoOpToolExecutor),
             response_store: Arc::new(NoOpResponseStore),
             body_limit: DEFAULT_BODY_LIMIT,
-            cache_pricer: None,
+            cache_classifier: None,
             cache_classify_deadline: cache::DEFAULT_CLASSIFY_DEADLINE,
         }
     }
@@ -373,7 +376,7 @@ impl<T: HttpClient> AppState<T> {
             tool_executor: Arc::new(NoOpToolExecutor),
             response_store: Arc::new(NoOpResponseStore),
             body_limit: DEFAULT_BODY_LIMIT,
-            cache_pricer: None,
+            cache_classifier: None,
             cache_classify_deadline: cache::DEFAULT_CLASSIFY_DEADLINE,
         }
     }
@@ -416,20 +419,20 @@ impl<T: HttpClient> AppState<T> {
         self
     }
 
-    /// Inject a cached-input-pricing hook (builder pattern, §6.2).
+    /// Inject a cached-input-classification hook (builder pattern, §6.2).
     ///
-    /// This is the **additive, optional** seam: wiring a pricer activates the
+    /// This is the **additive, optional** seam: wiring a classifier activates the
     /// request fork, `cache_control` stripping, and response usage injection.
     /// Leaving it unset (the default) keeps onwards byte-identical to today.
-    /// Pass [`cache::NoopCachePricer`] for an all-zero, behaviour-preserving
+    /// Pass [`cache::NoopCacheClassifier`] for an all-zero, behaviour-preserving
     /// activation (used for local end-to-end validation of the spine).
-    pub fn with_cache_pricer(mut self, pricer: Arc<dyn cache::CachePricer>) -> Self {
-        self.cache_pricer = Some(pricer);
+    pub fn with_cache_classifier(mut self, classifier: Arc<dyn cache::CacheClassifier>) -> Self {
+        self.cache_classifier = Some(classifier);
         self
     }
 
     /// Override the deadline for the parallel classify branch (builder pattern).
-    /// Only consulted when a pricer is wired.
+    /// Only consulted when a classifier is wired.
     pub fn with_cache_classify_deadline(mut self, deadline: std::time::Duration) -> Self {
         self.cache_classify_deadline = deadline;
         self
@@ -1253,7 +1256,7 @@ mod tests {
         }
     }
 
-    /// With NO pricer wired (the dormant default), the cache path is invisible:
+    /// With NO classifier wired (the dormant default), the cache path is invisible:
     /// `cache_control` markers pass through to the upstream untouched and the
     /// response carries no synthetic cache fields. This guards the
     /// non-breaking, behaviour-preserving contract for standalone onwards.
@@ -1262,7 +1265,7 @@ mod tests {
         let targets = single_target("test-model");
         let mock_response = r#"{"id":"c1","object":"chat.completion","model":"test-model","choices":[],"usage":{"prompt_tokens":9,"completion_tokens":2,"total_tokens":11}}"#;
         let mock_client = MockHttpClient::new(StatusCode::OK, mock_response);
-        // No .with_cache_pricer() — dormant.
+        // No .with_cache_classifier() — dormant.
         let app_state = AppState::with_client(targets, mock_client.clone());
         let server = TestServer::new(build_router(app_state)).unwrap();
 
@@ -1293,7 +1296,7 @@ mod tests {
         assert!(body["usage"].get("prompt_tokens_details").is_none());
     }
 
-    /// With the no-op pricer wired, the spine activates: the outbound request
+    /// With the no-op classifier wired, the spine activates: the outbound request
     /// has all `cache_control` stripped, and the (non-streaming) response usage
     /// carries the zeroed cache fields. Billing-relevant `prompt_tokens` is
     /// untouched.
@@ -1303,7 +1306,7 @@ mod tests {
         let mock_response = r#"{"id":"c1","object":"chat.completion","model":"test-model","choices":[],"usage":{"prompt_tokens":9,"completion_tokens":2,"total_tokens":11}}"#;
         let mock_client = MockHttpClient::new(StatusCode::OK, mock_response);
         let app_state = AppState::with_client(targets, mock_client.clone())
-            .with_cache_pricer(Arc::new(crate::cache::NoopCachePricer));
+            .with_cache_classifier(Arc::new(crate::cache::NoopCacheClassifier));
         let server = TestServer::new(build_router(app_state)).unwrap();
 
         let response = server
@@ -1342,7 +1345,45 @@ mod tests {
         assert_eq!(usage["cache_creation"]["ephemeral_24h_input_tokens"], 0);
     }
 
-    /// Streaming path: with the no-op pricer wired, the terminal usage frame
+    /// A NORMAL request (no `cache_control` markers) with the no-op classifier
+    /// wired must pass straight through: content forwarded unchanged, the
+    /// (zeroed) cache fields injected, `prompt_tokens` untouched, no error. This
+    /// is the common case — the classifier is active but the request opts out —
+    /// and proves the active path doesn't disturb ordinary traffic.
+    #[tokio::test]
+    async fn test_cache_seam_no_markers_wires_through_cleanly() {
+        let targets = single_target("test-model");
+        let mock_response = r#"{"id":"c1","object":"chat.completion","model":"test-model","choices":[],"usage":{"prompt_tokens":7,"completion_tokens":3,"total_tokens":10}}"#;
+        let mock_client = MockHttpClient::new(StatusCode::OK, mock_response);
+        let app_state = AppState::with_client(targets, mock_client.clone())
+            .with_cache_classifier(Arc::new(crate::cache::NoopCacheClassifier));
+        let server = TestServer::new(build_router(app_state)).unwrap();
+
+        let response = server
+            .post("/v1/chat/completions")
+            .json(&json!({
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "what's the weather?"}]
+            }))
+            .await;
+        assert_eq!(response.status_code(), 200);
+
+        // Outbound request forwarded unchanged (nothing to strip).
+        let forwarded: serde_json::Value =
+            serde_json::from_slice(&mock_client.get_requests()[0].body).unwrap();
+        assert_eq!(forwarded["messages"][0]["content"], "what's the weather?");
+
+        // Response usage: zeroed cache fields injected, original counts untouched.
+        let body: serde_json::Value = response.json();
+        let usage = &body["usage"];
+        assert_eq!(usage["prompt_tokens"], 7);
+        assert_eq!(usage["completion_tokens"], 3);
+        assert_eq!(usage["prompt_tokens_details"]["cached_tokens"], 0);
+        assert_eq!(usage["cache_read_input_tokens"], 0);
+        assert_eq!(usage["cache_creation_input_tokens"], 0);
+    }
+
+    /// Streaming path: with the no-op classifier wired, the terminal usage frame
     /// gets the zeroed cache fields injected while delta chunks and `[DONE]`
     /// pass through untouched.
     #[tokio::test]
@@ -1355,7 +1396,7 @@ mod tests {
         ];
         let mock_client = MockHttpClient::new_streaming(StatusCode::OK, chunks);
         let app_state = AppState::with_client(targets, mock_client.clone())
-            .with_cache_pricer(Arc::new(crate::cache::NoopCachePricer));
+            .with_cache_classifier(Arc::new(crate::cache::NoopCacheClassifier));
         let server = TestServer::new(build_router(app_state)).unwrap();
 
         let response = server

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,8 @@ use std::sync::Arc;
 use tracing::{info, instrument};
 
 pub mod auth;
+pub mod cache;
+pub mod cache_usage;
 pub mod client;
 pub mod config;
 pub mod errors;
@@ -64,6 +66,9 @@ pub mod target;
 pub mod telemetry;
 pub mod traits;
 
+pub use cache::{
+    CachePricer, CacheStats, ClassifyInput, DEFAULT_CLASSIFY_DEADLINE, NoopCachePricer,
+};
 use client::{HttpClient, HyperClient};
 use handlers::{models as models_handler, target_message_handler};
 use models::ExtractedModel;
@@ -231,6 +236,23 @@ pub struct AppState<T: HttpClient> {
     /// `DefaultBodyLimit`, which rejects large (e.g. long-context or base64
     /// image) payloads with a 413. Defaults to [`DEFAULT_BODY_LIMIT`].
     pub body_limit: usize,
+    /// Optional cached-input-pricing hook (the onwards ↔ dwctl seam, §6.2).
+    ///
+    /// Defaults to `None`, in which case the entire cache path is dormant and
+    /// onwards behaviour is byte-identical to today (no fork, no
+    /// `cache_control` stripping, no usage injection). When set via
+    /// [`AppState::with_cache_pricer`], onwards forks each request to the
+    /// pricer in parallel with the upstream call and injects the resulting
+    /// [`cache::CacheStats`] into the response `usage`. The default
+    /// [`cache::NoopCachePricer`] returns all-zero stats, so even when wired
+    /// the injected fields are zero and downstream billing is unaffected.
+    pub cache_pricer: Option<Arc<dyn cache::CachePricer>>,
+    /// Deadline for the parallel classify branch. The response join waits at
+    /// most this long for [`cache::CachePricer::classify`] before falling back
+    /// to all-zero stats (best-effort, billed as un-cached). Only consulted
+    /// when `cache_pricer` is `Some`. Defaults to
+    /// [`cache::DEFAULT_CLASSIFY_DEADLINE`].
+    pub cache_classify_deadline: std::time::Duration,
 }
 
 /// Default maximum request body size (32 MB).
@@ -258,6 +280,11 @@ impl<T: HttpClient> std::fmt::Debug for AppState<T> {
             .field("tool_executor", &"<dyn ToolExecutor>")
             .field("response_store", &"<dyn ResponseStore>")
             .field("body_limit", &self.body_limit)
+            .field(
+                "cache_pricer",
+                &self.cache_pricer.as_ref().map(|_| "<dyn CachePricer>"),
+            )
+            .field("cache_classify_deadline", &self.cache_classify_deadline)
             .finish()
     }
 }
@@ -282,6 +309,8 @@ impl AppState<HyperClient> {
             tool_executor: Arc::new(NoOpToolExecutor),
             response_store: Arc::new(NoOpResponseStore),
             body_limit: DEFAULT_BODY_LIMIT,
+            cache_pricer: None,
+            cache_classify_deadline: cache::DEFAULT_CLASSIFY_DEADLINE,
         }
     }
 
@@ -304,6 +333,8 @@ impl AppState<HyperClient> {
             tool_executor: Arc::new(NoOpToolExecutor),
             response_store: Arc::new(NoOpResponseStore),
             body_limit: DEFAULT_BODY_LIMIT,
+            cache_pricer: None,
+            cache_classify_deadline: cache::DEFAULT_CLASSIFY_DEADLINE,
         }
     }
 }
@@ -321,6 +352,8 @@ impl<T: HttpClient> AppState<T> {
             tool_executor: Arc::new(NoOpToolExecutor),
             response_store: Arc::new(NoOpResponseStore),
             body_limit: DEFAULT_BODY_LIMIT,
+            cache_pricer: None,
+            cache_classify_deadline: cache::DEFAULT_CLASSIFY_DEADLINE,
         }
     }
 
@@ -340,6 +373,8 @@ impl<T: HttpClient> AppState<T> {
             tool_executor: Arc::new(NoOpToolExecutor),
             response_store: Arc::new(NoOpResponseStore),
             body_limit: DEFAULT_BODY_LIMIT,
+            cache_pricer: None,
+            cache_classify_deadline: cache::DEFAULT_CLASSIFY_DEADLINE,
         }
     }
 
@@ -378,6 +413,25 @@ impl<T: HttpClient> AppState<T> {
     /// Applies to both the strict and non-strict routers.
     pub fn with_body_limit(mut self, limit: usize) -> Self {
         self.body_limit = limit;
+        self
+    }
+
+    /// Inject a cached-input-pricing hook (builder pattern, §6.2).
+    ///
+    /// This is the **additive, optional** seam: wiring a pricer activates the
+    /// request fork, `cache_control` stripping, and response usage injection.
+    /// Leaving it unset (the default) keeps onwards byte-identical to today.
+    /// Pass [`cache::NoopCachePricer`] for an all-zero, behaviour-preserving
+    /// activation (used for local end-to-end validation of the spine).
+    pub fn with_cache_pricer(mut self, pricer: Arc<dyn cache::CachePricer>) -> Self {
+        self.cache_pricer = Some(pricer);
+        self
+    }
+
+    /// Override the deadline for the parallel classify branch (builder pattern).
+    /// Only consulted when a pricer is wired.
+    pub fn with_cache_classify_deadline(mut self, deadline: std::time::Duration) -> Self {
+        self.cache_classify_deadline = deadline;
         self
     }
 }
@@ -1175,6 +1229,154 @@ mod tests {
         assert_eq!(forwarded_body["model"], "test-model");
         assert_eq!(forwarded_body["messages"][0]["content"], "Hello!");
         assert_eq!(forwarded_body["temperature"], 0.7);
+    }
+
+    /// Helper: a single-target Targets for the cache-seam tests.
+    fn single_target(model: &str) -> Targets {
+        let targets_map = Arc::new(DashMap::new());
+        targets_map.insert(
+            model.to_string(),
+            pool(
+                Target::builder()
+                    .url("https://api.example.com".parse().unwrap())
+                    .onwards_key("test-api-key".to_string())
+                    .build(),
+            ),
+        );
+        Targets {
+            targets: targets_map,
+            key_rate_limiters: Arc::new(DashMap::new()),
+            key_concurrency_limiters: Arc::new(DashMap::new()),
+            key_labels: Arc::new(DashMap::new()),
+            strict_mode: false,
+            http_pool_config: None,
+        }
+    }
+
+    /// With NO pricer wired (the dormant default), the cache path is invisible:
+    /// `cache_control` markers pass through to the upstream untouched and the
+    /// response carries no synthetic cache fields. This guards the
+    /// non-breaking, behaviour-preserving contract for standalone onwards.
+    #[tokio::test]
+    async fn test_cache_seam_dormant_by_default() {
+        let targets = single_target("test-model");
+        let mock_response = r#"{"id":"c1","object":"chat.completion","model":"test-model","choices":[],"usage":{"prompt_tokens":9,"completion_tokens":2,"total_tokens":11}}"#;
+        let mock_client = MockHttpClient::new(StatusCode::OK, mock_response);
+        // No .with_cache_pricer() — dormant.
+        let app_state = AppState::with_client(targets, mock_client.clone());
+        let server = TestServer::new(build_router(app_state)).unwrap();
+
+        let response = server
+            .post("/v1/chat/completions")
+            .json(&json!({
+                "model": "test-model",
+                "messages": [{"role": "user", "content": [
+                    {"type": "text", "text": "hi", "cache_control": {"type": "ephemeral"}}
+                ]}]
+            }))
+            .await;
+        assert_eq!(response.status_code(), 200);
+
+        // cache_control reached the upstream untouched (no stripping).
+        let forwarded: serde_json::Value =
+            serde_json::from_slice(&mock_client.get_requests()[0].body).unwrap();
+        assert!(
+            forwarded["messages"][0]["content"][0]
+                .get("cache_control")
+                .is_some(),
+            "dormant onwards must NOT strip cache_control"
+        );
+
+        // Response usage carries no synthetic cache fields.
+        let body: serde_json::Value = response.json();
+        assert!(body["usage"].get("cache_read_input_tokens").is_none());
+        assert!(body["usage"].get("prompt_tokens_details").is_none());
+    }
+
+    /// With the no-op pricer wired, the spine activates: the outbound request
+    /// has all `cache_control` stripped, and the (non-streaming) response usage
+    /// carries the zeroed cache fields. Billing-relevant `prompt_tokens` is
+    /// untouched.
+    #[tokio::test]
+    async fn test_cache_seam_noop_strips_and_injects_non_streaming() {
+        let targets = single_target("test-model");
+        let mock_response = r#"{"id":"c1","object":"chat.completion","model":"test-model","choices":[],"usage":{"prompt_tokens":9,"completion_tokens":2,"total_tokens":11}}"#;
+        let mock_client = MockHttpClient::new(StatusCode::OK, mock_response);
+        let app_state = AppState::with_client(targets, mock_client.clone())
+            .with_cache_pricer(Arc::new(crate::cache::NoopCachePricer));
+        let server = TestServer::new(build_router(app_state)).unwrap();
+
+        let response = server
+            .post("/v1/chat/completions")
+            .json(&json!({
+                "model": "test-model",
+                "messages": [{"role": "user", "content": [
+                    {"type": "text", "text": "hi", "cache_control": {"type": "ephemeral", "ttl": "1h"}}
+                ]}],
+                "cache_control": {"type": "ephemeral"}
+            }))
+            .await;
+        assert_eq!(response.status_code(), 200);
+
+        // Outbound request: every cache_control stripped (recursively).
+        let forwarded: serde_json::Value =
+            serde_json::from_slice(&mock_client.get_requests()[0].body).unwrap();
+        assert!(forwarded.get("cache_control").is_none());
+        assert!(
+            forwarded["messages"][0]["content"][0]
+                .get("cache_control")
+                .is_none()
+        );
+        // Content otherwise intact.
+        assert_eq!(forwarded["messages"][0]["content"][0]["text"], "hi");
+
+        // Response usage: zeroed cache fields present, prompt_tokens untouched.
+        let body: serde_json::Value = response.json();
+        let usage = &body["usage"];
+        assert_eq!(usage["prompt_tokens"], 9);
+        assert_eq!(usage["prompt_tokens_details"]["cached_tokens"], 0);
+        assert_eq!(usage["cache_read_input_tokens"], 0);
+        assert_eq!(usage["cache_creation_input_tokens"], 0);
+        assert_eq!(usage["cache_creation"]["ephemeral_5m_input_tokens"], 0);
+        assert_eq!(usage["cache_creation"]["ephemeral_1h_input_tokens"], 0);
+        assert_eq!(usage["cache_creation"]["ephemeral_24h_input_tokens"], 0);
+    }
+
+    /// Streaming path: with the no-op pricer wired, the terminal usage frame
+    /// gets the zeroed cache fields injected while delta chunks and `[DONE]`
+    /// pass through untouched.
+    #[tokio::test]
+    async fn test_cache_seam_noop_injects_streaming_terminal_frame() {
+        let targets = single_target("test-model");
+        let chunks = vec![
+            "data: {\"id\":\"c1\",\"object\":\"chat.completion.chunk\",\"model\":\"test-model\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hi\"}}]}\n\n".to_string(),
+            "data: {\"id\":\"c1\",\"object\":\"chat.completion.chunk\",\"model\":\"test-model\",\"choices\":[],\"usage\":{\"prompt_tokens\":9,\"completion_tokens\":2,\"total_tokens\":11}}\n\n".to_string(),
+            "data: [DONE]\n\n".to_string(),
+        ];
+        let mock_client = MockHttpClient::new_streaming(StatusCode::OK, chunks);
+        let app_state = AppState::with_client(targets, mock_client.clone())
+            .with_cache_pricer(Arc::new(crate::cache::NoopCachePricer));
+        let server = TestServer::new(build_router(app_state)).unwrap();
+
+        let response = server
+            .post("/v1/chat/completions")
+            .json(&json!({
+                "model": "test-model",
+                "stream": true,
+                "messages": [{"role": "user", "content": "hi"}]
+            }))
+            .await;
+        assert_eq!(response.status_code(), 200);
+
+        let text = response.text();
+        // Delta chunk untouched.
+        assert!(text.contains("\"delta\":{\"content\":\"hi\"}"));
+        // Terminal usage frame got zeroed cache fields.
+        assert!(text.contains("\"cache_read_input_tokens\":0"));
+        assert!(text.contains("\"cached_tokens\":0"));
+        assert!(text.contains("\"cache_creation_input_tokens\":0"));
+        // [DONE] preserved.
+        assert!(text.contains("data: [DONE]"));
     }
 
     #[tokio::test]

--- a/src/response_id.rs
+++ b/src/response_id.rs
@@ -126,8 +126,8 @@ pub async fn patch_response_body_id(response: &mut Response<Body>, override_id: 
 mod tests {
     use super::*;
     use axum::http::StatusCode;
-    use flate2::write::GzEncoder;
     use flate2::Compression;
+    use flate2::write::GzEncoder;
     use std::io::Write as _;
 
     // --- extract_override_id ---
@@ -181,7 +181,9 @@ mod tests {
 
     #[test]
     fn path_supports_id_override_with_query_string() {
-        assert!(path_supports_id_override("/v1/chat/completions?stream=true"));
+        assert!(path_supports_id_override(
+            "/v1/chat/completions?stream=true"
+        ));
         assert!(path_supports_id_override("/v1/responses?foo=bar"));
     }
 
@@ -240,7 +242,9 @@ mod tests {
 
         patch_response_body_id(&mut response, "resp_override".to_string()).await;
 
-        let result = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let result = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&result).unwrap();
         assert_eq!(json["id"], "resp_override");
         assert_eq!(json["model"], "gpt-4");
@@ -261,7 +265,9 @@ mod tests {
 
         // Should be decompressed after patching
         assert!(response.headers().get("content-encoding").is_none());
-        let result = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let result = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&result).unwrap();
         assert_eq!(json["id"], "resp_patched");
     }
@@ -280,7 +286,9 @@ mod tests {
         patch_response_body_id(&mut response, "resp_br_patched".to_string()).await;
 
         assert!(response.headers().get("content-encoding").is_none());
-        let result = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let result = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&result).unwrap();
         assert_eq!(json["id"], "resp_br_patched");
     }
@@ -292,7 +300,9 @@ mod tests {
 
         patch_response_body_id(&mut response, "resp_ignored".to_string()).await;
 
-        let result = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let result = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
         assert_eq!(result.as_ref(), b"not json");
     }
 
@@ -303,7 +313,9 @@ mod tests {
 
         patch_response_body_id(&mut response, "resp_noop".to_string()).await;
 
-        let result = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let result = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&result).unwrap();
         assert!(json.get("id").is_none());
     }
@@ -315,8 +327,17 @@ mod tests {
 
         patch_response_body_id(&mut response, "resp_much-longer-id-value".to_string()).await;
 
-        let cl: usize = response.headers().get("content-length").unwrap().to_str().unwrap().parse().unwrap();
-        let result = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let cl: usize = response
+            .headers()
+            .get("content-length")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .parse()
+            .unwrap();
+        let result = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
         assert_eq!(cl, result.len());
     }
 }

--- a/src/strict/handlers.rs
+++ b/src/strict/handlers.rs
@@ -240,7 +240,8 @@ pub async fn responses_handler<T: HttpClient + Clone + Send + Sync + 'static>(
     if use_adapter {
         // Adapter mode: convert to Chat Completions, forward, convert back
         debug!(model = %request.model, "Using Open Responses adapter");
-        return handle_adapter_request(state, headers, request, extensions, effective_response_id).await;
+        return handle_adapter_request(state, headers, request, extensions, effective_response_id)
+            .await;
     }
 
     // Passthrough mode: forward request as-is
@@ -294,7 +295,13 @@ pub async fn responses_handler<T: HttpClient + Clone + Send + Sync + 'static>(
         let response_is_sse = response_is_sse(&response);
 
         if is_streaming || response_is_sse {
-            sanitize_streaming_responses_response(response, resolved_model, trusted, response_id_override).await
+            sanitize_streaming_responses_response(
+                response,
+                resolved_model,
+                trusted,
+                response_id_override,
+            )
+            .await
         } else {
             sanitize_responses_response(response, resolved_model, response_id_override).await
         }
@@ -311,18 +318,26 @@ pub async fn responses_handler<T: HttpClient + Clone + Send + Sync + 'static>(
         // extract the body without consuming it, so we store the response_id mapping only.
         // The provider's response already contains its own ID; downstream consumers
         // (GET /v1/responses/{id}) will use the fusillade row.
-        if let Err(e) = state.response_store.complete(
-            &response_id,
-            &serde_json::json!({"passthrough": true}),
-            final_response.status().as_u16(),
-        ).await {
+        if let Err(e) = state
+            .response_store
+            .complete(
+                &response_id,
+                &serde_json::json!({"passthrough": true}),
+                final_response.status().as_u16(),
+            )
+            .await
+        {
             warn!(error = %e, response_id = %response_id, "Failed to mark response as completed");
         }
     } else {
-        if let Err(e) = state.response_store.fail(
-            &response_id,
-            &format!("Upstream returned {}", final_response.status()),
-        ).await {
+        if let Err(e) = state
+            .response_store
+            .fail(
+                &response_id,
+                &format!("Upstream returned {}", final_response.status()),
+            )
+            .await
+        {
             warn!(error = %e, response_id = %response_id, "Failed to mark response as failed");
         }
     }
@@ -709,10 +724,14 @@ async fn handle_adapter_request<T: HttpClient + Clone + Send + Sync + 'static>(
         // Check if the response is successful
         if !response.status().is_success() {
             // Mark as failed in the response store
-            if let Err(e) = state.response_store.fail(
-                &response_id,
-                &format!("Upstream returned {}", response.status()),
-            ).await {
+            if let Err(e) = state
+                .response_store
+                .fail(
+                    &response_id,
+                    &format!("Upstream returned {}", response.status()),
+                )
+                .await
+            {
                 warn!(error = %e, response_id = %response_id, "Failed to mark response as failed");
             }
             // Pass through error responses
@@ -867,11 +886,11 @@ async fn handle_adapter_request<T: HttpClient + Clone + Send + Sync + 'static>(
 
         // Mark as completed in the response store
         if let Ok(response_value) = serde_json::to_value(&responses_response) {
-            if let Err(e) = state.response_store.complete(
-                &response_id,
-                &response_value,
-                parts.status.as_u16(),
-            ).await {
+            if let Err(e) = state
+                .response_store
+                .complete(&response_id, &response_value, parts.status.as_u16())
+                .await
+            {
                 warn!(error = %e, response_id = %response_id, "Failed to mark response as completed");
             }
         }
@@ -1826,7 +1845,11 @@ async fn sanitize_embeddings_response(mut response: Response, original_model: St
 ///
 /// Deserializes the response through our strict schema (drops extra fields),
 /// rewrites the model field, and re-serializes.
-async fn sanitize_responses_response(mut response: Response, original_model: String, response_id_override: Option<String>) -> Response {
+async fn sanitize_responses_response(
+    mut response: Response,
+    original_model: String,
+    response_id_override: Option<String>,
+) -> Response {
     let body_bytes =
         match axum::body::to_bytes(std::mem::take(response.body_mut()), usize::MAX).await {
             Ok(bytes) => bytes,
@@ -1926,7 +1949,9 @@ async fn sanitize_streaming_responses_response(
         http_body_util::BodyExt::into_data_stream(std::mem::take(response.body_mut()));
     let buffered_stream = crate::sse::SseBufferedStream::new(body_stream);
     let response_id_override = response_id_override.clone();
-    let stream_fallback_response_id = response_id_override.clone().unwrap_or_else(generated_response_id);
+    let stream_fallback_response_id = response_id_override
+        .clone()
+        .unwrap_or_else(generated_response_id);
 
     let sanitized_stream = buffered_stream.map(move |chunk_result| {
         match chunk_result {
@@ -3931,7 +3956,8 @@ mod tests {
             .unwrap();
 
         let result =
-            sanitize_streaming_responses_response(response, "test-model".to_string(), true, None).await;
+            sanitize_streaming_responses_response(response, "test-model".to_string(), true, None)
+                .await;
         assert_eq!(result.status(), StatusCode::OK);
 
         let body = axum::body::to_bytes(result.into_body(), usize::MAX)

--- a/src/target.rs
+++ b/src/target.rs
@@ -2357,9 +2357,20 @@ mod tests {
 
         let pool_config = list.into_pool_config().unwrap();
         assert_eq!(pool_config.providers.len(), 3);
-        assert_eq!(pool_config.providers[0].propagate_trace_context, Some(true), "explicit true must survive");
-        assert_eq!(pool_config.providers[1].propagate_trace_context, Some(false), "explicit false must survive");
-        assert_eq!(pool_config.providers[2].propagate_trace_context, None, "unset stays None (inherits resolved trusted)");
+        assert_eq!(
+            pool_config.providers[0].propagate_trace_context,
+            Some(true),
+            "explicit true must survive"
+        );
+        assert_eq!(
+            pool_config.providers[1].propagate_trace_context,
+            Some(false),
+            "explicit false must survive"
+        );
+        assert_eq!(
+            pool_config.providers[2].propagate_trace_context, None,
+            "unset stays None (inherits resolved trusted)"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Adds the onwards side of cached-input pricing as dormant, price-agnostic plumbing — no-op and byte-identical to today unless a classifier is injected. onwards only classifies (tags requests with cache read/write token stats); all pricing/billing semantics stay in dwctl.

- `cache.rs: CacheClassifier` trait (`async classify`), neutral `CacheStats {read, creation_5m/1h/24h}`, `NoopCacheClassifier`.
- `cache_usage.rs`: the OpenAI usage adapter — strip `cache_control` from the outbound request; inject the `cache_*` usage fields on the way out. Non-streaming JSON splice; streaming terminal SSE frame rewrite, wrapped in `SseBufferedStream` so split events are handled, with Content-Length dropped.
- `AppState`: additive, defaulted `cache_classifier: Option<Arc<dyn CacheClassifier>>` + `with_cache_classifier(...)`. No existing constructor changed, version unchanged → independent, non-breaking release.
- `handlers.rs`: when a classifier is wired, fork (spawn `classify` concurrent with the upstream call), strip markers, then join under a deadline and inject. `AbortOnDrop` aborts the classify on any failure/early-return (safe — index writes are success-gated), lets it finish on success.
- Dormant default (`None`): no fork, strip, or injection; strict router inherits the gated path.
Tests: dormant pass-through, normal (no-marker) wire-through, marker strip + inject, streaming terminal-frame, split-chunk SSE, non-JSON skip. No real classification yet — that lands behind this seam.