### PR TITLE
feat: add api_key to ClassifyInput for per-customer cache scoping

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -49,6 +49,7 @@ pub const DEFAULT_CLASSIFY_DEADLINE: Duration = Duration::from_secs(5);
 /// the rewritten underlying `model_name` — see `handlers.rs`), and the request
 /// body it must parse for `cache_control` markers. Kept minimal but real.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct ClassifyInput {
     /// The virtual model string the client sent (the cache key dimension).
     /// This is the `OriginalModel` retained in request extensions, before
@@ -61,6 +62,12 @@ pub struct ClassifyInput {
     /// parses for `cache_control` markers). This is the *pre-strip* body, so
     /// the markers are still present for the classifier to read.
     pub body: bytes::Bytes,
+    /// The raw bearer token the request authenticated with — the API key secret
+    /// in this system. onwards holds no notion of users; the classifier resolves
+    /// this to a billing principal (e.g. `user_id`/`org_id`) to scope the cache
+    /// per customer. `None` when the request carried no bearer token, in which
+    /// case the request is un-scopable and a classifier should not cache it.
+    pub api_key: Option<String>,
 }
 
 /// The paradigm-neutral result of classification: the read/write token split.
@@ -171,6 +178,7 @@ mod tests {
             body: bytes::Bytes::from_static(
                 br#"{"model":"my-virtual-model","messages":[{"role":"user","content":"hi"}]}"#,
             ),
+            api_key: Some("sk-test".to_string()),
         };
         let stats = classifier.classify(&input).await;
         assert_eq!(stats, CacheStats::default());

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -48,7 +48,7 @@ pub const DEFAULT_CLASSIFY_DEADLINE: Duration = Duration::from_secs(5);
 /// **virtual** model string (the user-facing alias / `OriginalModel`, *not*
 /// the rewritten underlying `model_name` — see `handlers.rs`), and the request
 /// body it must parse for `cache_control` markers. Kept minimal but real.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 #[non_exhaustive]
 pub struct ClassifyInput {
     /// The virtual model string the client sent (the cache key dimension).
@@ -68,6 +68,20 @@ pub struct ClassifyInput {
     /// per customer. `None` when the request carried no bearer token, in which
     /// case the request is un-scopable and a classifier should not cache it.
     pub api_key: Option<String>,
+}
+
+// Manual Debug that REDACTS `api_key`: it is a raw credential secret, and a derived
+// Debug would leak it into any `{:?}` log/error line. Presence/absence is preserved
+// (useful for debugging) but never the value.
+impl std::fmt::Debug for ClassifyInput {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ClassifyInput")
+            .field("virtual_model", &self.virtual_model)
+            .field("path", &self.path)
+            .field("body", &self.body)
+            .field("api_key", &self.api_key.as_ref().map(|_| "<redacted>"))
+            .finish()
+    }
 }
 
 /// The paradigm-neutral result of classification: the read/write token split.
@@ -183,5 +197,28 @@ mod tests {
         let stats = classifier.classify(&input).await;
         assert_eq!(stats, CacheStats::default());
         assert!(stats.is_zero());
+    }
+
+    #[test]
+    fn classify_input_debug_redacts_api_key() {
+        let input = ClassifyInput {
+            virtual_model: "m".to_string(),
+            path: "/v1/chat/completions".to_string(),
+            body: bytes::Bytes::from_static(b"{}"),
+            api_key: Some("sk-super-secret-token".to_string()),
+        };
+        let dbg = format!("{input:?}");
+        assert!(
+            !dbg.contains("sk-super-secret-token"),
+            "Debug leaked the api_key: {dbg}"
+        );
+        assert!(dbg.contains("<redacted>"), "Debug should redact: {dbg}");
+
+        // None renders without a redaction marker.
+        let none_input = ClassifyInput {
+            api_key: None,
+            ..input
+        };
+        assert!(format!("{none_input:?}").contains("api_key: None"));
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -62,11 +62,13 @@ pub struct ClassifyInput {
     /// parses for `cache_control` markers). This is the *pre-strip* body, so
     /// the markers are still present for the classifier to read.
     pub body: bytes::Bytes,
-    /// The raw bearer token the request authenticated with — the API key secret
-    /// in this system. onwards holds no notion of users; the classifier resolves
-    /// this to a billing principal (e.g. `user_id`/`org_id`) to scope the cache
-    /// per customer. `None` when the request carried no bearer token, in which
-    /// case the request is un-scopable and a classifier should not cache it.
+    /// The bearer token the request authenticated with — the API key secret in
+    /// this system — but **only when it validated against the pool serving the
+    /// request**. onwards holds no notion of users; the classifier resolves this
+    /// to a billing principal (e.g. `user_id`/`org_id`) to scope the cache per
+    /// customer. `None` whenever the request did not authenticate via a validated
+    /// bearer token (missing/invalid `Authorization` header, or an open pool with
+    /// no key set) — the request is then un-scopable and must not be cached.
     pub api_key: Option<String>,
 }
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -78,7 +78,8 @@ impl std::fmt::Debug for ClassifyInput {
         f.debug_struct("ClassifyInput")
             .field("virtual_model", &self.virtual_model)
             .field("path", &self.path)
-            .field("body", &self.body)
+            // length only: the body can be large and carry sensitive prompt content.
+            .field("body_len", &self.body.len())
             .field("api_key", &self.api_key.as_ref().map(|_| "<redacted>"))
             .finish()
     }
@@ -192,7 +193,7 @@ mod tests {
             body: bytes::Bytes::from_static(
                 br#"{"model":"my-virtual-model","messages":[{"role":"user","content":"hi"}]}"#,
             ),
-            api_key: Some("sk-test".to_string()),
+            api_key: Some("test-token".to_string()),
         };
         let stats = classifier.classify(&input).await;
         assert_eq!(stats, CacheStats::default());
@@ -201,17 +202,15 @@ mod tests {
 
     #[test]
     fn classify_input_debug_redacts_api_key() {
+        let secret = "totally-not-a-real-token";
         let input = ClassifyInput {
             virtual_model: "m".to_string(),
             path: "/v1/chat/completions".to_string(),
             body: bytes::Bytes::from_static(b"{}"),
-            api_key: Some("sk-super-secret-token".to_string()),
+            api_key: Some(secret.to_string()),
         };
         let dbg = format!("{input:?}");
-        assert!(
-            !dbg.contains("sk-super-secret-token"),
-            "Debug leaked the api_key: {dbg}"
-        );
+        assert!(!dbg.contains(secret), "Debug leaked the api_key: {dbg}");
         assert!(dbg.contains("<redacted>"), "Debug should redact: {dbg}");
 
         // None renders without a redaction marker.

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -524,10 +524,16 @@ pub async fn target_message_handler<T: HttpClient>(
                 virtual_model: model_name.clone(),
                 path,
                 body: body_bytes.clone(),
-                // onwards is identity-agnostic: hand the raw bearer token to the
-                // classifier, which resolves it to a billing principal (user/org)
-                // to scope the cache per customer.
-                api_key: bearer_token.map(|t| t.to_string()),
+                // onwards is identity-agnostic: hand the raw *validated* bearer token
+                // to the classifier, which resolves it to a billing principal
+                // (user/org) to scope the cache per customer. Only pass it when the
+                // pool actually has keys to validate against — an open pool never
+                // authenticated the token, so it must not influence cache scoping.
+                api_key: if pool.keys().is_some() {
+                    bearer_token.map(|t| t.to_string())
+                } else {
+                    None
+                },
             };
             let handle = tokio::spawn(async move { classifier.classify(&classify_input).await });
 

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -524,15 +524,20 @@ pub async fn target_message_handler<T: HttpClient>(
                 virtual_model: model_name.clone(),
                 path,
                 body: body_bytes.clone(),
-                // onwards is identity-agnostic: hand the raw *validated* bearer token
-                // to the classifier, which resolves it to a billing principal
-                // (user/org) to scope the cache per customer. Only pass it when the
-                // pool actually has keys to validate against — an open pool never
-                // authenticated the token, so it must not influence cache scoping.
-                api_key: if pool.keys().is_some() {
-                    bearer_token.map(|t| t.to_string())
-                } else {
-                    None
+                // onwards is identity-agnostic: hand the raw bearer token to the
+                // classifier, which resolves it to a billing principal (user/org) to
+                // scope the cache per customer. RE-VALIDATE it here against the pool
+                // actually serving the request: `pool` may have been reassigned by a
+                // routing-rule redirect since the initial auth check, so gating on
+                // `pool.keys().is_some()` alone could pass an unvalidated token (an
+                // open pool redirected to a keyed one). Only a token that validates
+                // against the serving pool becomes the principal — never an
+                // unauthenticated caller (cross-tenant / billing-isolation safety).
+                api_key: match (pool.keys(), bearer_token) {
+                    (Some(keys), Some(token)) if auth::validate_bearer_token(keys, token) => {
+                        Some(token.to_string())
+                    }
+                    _ => None,
                 },
             };
             let handle = tokio::spawn(async move { classifier.classify(&classify_input).await });

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -524,6 +524,10 @@ pub async fn target_message_handler<T: HttpClient>(
                 virtual_model: model_name.clone(),
                 path,
                 body: body_bytes.clone(),
+                // onwards is identity-agnostic: hand the raw bearer token to the
+                // classifier, which resolves it to a billing principal (user/org)
+                // to scope the cache per customer.
+                api_key: bearer_token.map(|t| t.to_string()),
             };
             let handle = tokio::spawn(async move { classifier.classify(&classify_input).await });
 


### PR DESCRIPTION
Summary
Extends the cached-input-classification seam (shipped dormant in 0.32.0) so a real classifier can scope its cache per customer. ClassifyInput gains the bearer token the request authenticated with; onwards stays completely identity-agnostic — it just hands over the token it already validated, and the downstream classifier (dwctl) resolves it to a billing principal.

Why
The no-op classifier needs nothing about who is calling. A real one does: Anthropic-style caching is per-customer (a customer's cached prefixes must not count as hits for anyone else — both a correctness and a billing-isolation requirement), so the index is keyed on the caller's identity. That identity isn't in the request body, path, or model — it's the API key in the Authorization header, which the classifier never saw. onwards already has the validated bearer token at the fork point, so it now threads it through.

onwards holds no notion of users; resolving the token → user_id/org_id is entirely the consumer's job.

Changes
ClassifyInput gains pub api_key: Option<String> — the raw bearer token (the API key secret in this system); None when the request carried no bearer token (→ un-scopable, don't cache).
ClassifyInput is now #[non_exhaustive].
The handler populates api_key at the classify fork (bearer_token.map(|t| t.to_string())); struct + both construction sites updated.
Semver
Pre-1.0 breaking-minor → 0.33.0 (cargo-semver-checks flags both the new field on a constructible struct and the #[non_exhaustive] addition). In practice it's additive: only dwctl consumes ClassifyInput, and it reads fields rather than constructing it, so nothing downstream breaks. #[non_exhaustive] is the point — from here on, adding fields to ClassifyInput (we'll likely add a request/trace id, maybe headers, as the classifier grows) is non-breaking. Behaviour is unchanged: still fully dormant unless a classifier is wired.

Testing
413/413 lib tests pass; cargo fmt --check clean.

