### PR TITLE
fix(deps): bump fusillade to 19.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,9 +978,9 @@ dependencies = [
 
 [[package]]
 name = "fusillade"
-version = "18.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a159b6aaa3c49930fe3688c87821bd49900c88d7981506e0785d484e8d42b38"
+checksum = "57dce5742d2d6c717c89407c7c75d6d5e4fe45180b0859b6bc187c1c503bc668"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ metrics = "0.24"
 governor = "0.10.1"
 rand = "0.9"
 uuid = { version = "1", features = ["v4"] }
-fusillade = { version = ">=17.0.2, <19", optional = true }
+fusillade = { version = ">=17.0.2, <20", optional = true }
 
 [dev-dependencies]
 axum-test = "18.0.0"


### PR DESCRIPTION
## What

Widens the optional `fusillade` dependency range from `>=17.0.2, <19` to
`>=17.0.2, <20` and pins the lockfile to **fusillade 19.0.0**.

## Why

fusillade 19.0.0 is published; dwctl is moving to it. onwards re-exports
fusillade types (`HttpClient`, `RequestData`, `StreamEvent`, `RequestId`,
`ReqwestHttpClient`) through the `multi-step` feature, so its published
range must admit 19.x or dwctl can't resolve fusillade 19 alongside
onwards.

## Verification

- `cargo check --features multi-step` — clean against fusillade 19.0.0
- `cargo test --features multi-step response_loop` — 13 passed, 0 failed
- No source changes needed; the API onwards uses is unchanged across the
  18→19 major.

🤖 Generated with [Claude Code](https://claude.com/claude-code)