### PR TITLE
fix(deps): bump fusillade to 19.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,9 +978,9 @@ dependencies = [
 
 [[package]]
 name = "fusillade"
-version = "19.0.0"
+version = "19.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57dce5742d2d6c717c89407c7c75d6d5e4fe45180b0859b6bc187c1c503bc668"
+checksum = "2a89113de963b8279cc0f538706227dc7980d22c1688d7f3347b2e6ca6b5bd3f"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
## What

Bumps the lockfile pin for the optional `fusillade` dependency from **19.0.0** to **19.0.1** (latest published). The `>=17.0.2, <20` range in `Cargo.toml` already admits it, so no manifest change is needed.

## Why

fusillade 19.0.1 is the latest published patch release. Keeping onwards' lockfile current ensures CI and downstream consumers resolve against the newest fusillade 19.x.

## Verification

- `cargo check --features multi-step` — clean against fusillade 19.0.1
- `cargo test --features multi-step response_loop` — 13 passed, 0 failed
- No source changes; the API onwards re-exports is unchanged across the patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)