### PR TITLE
feat: strict /messages alias and preserve choices[].stop_reason

### DIFF
--- a/src/response_sanitizer.rs
+++ b/src/response_sanitizer.rs
@@ -63,6 +63,11 @@ struct LenientChoice {
     finish_reason: Option<String>,
     #[serde(default)]
     logprobs: Option<serde_json::Value>,
+    /// vLLM/sglang report the matched stop sequence (a string, or a token id)
+    /// here. Preserved through sanitization so downstream readers (e.g. the
+    /// Anthropic `stop_sequence` translation) can see it; omitted when absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    stop_reason: Option<serde_json::Value>,
     /// Catch-all for unknown fields (ignored during serialization)
     #[serde(flatten, skip_serializing)]
     _extra: HashMap<String, serde_json::Value>,
@@ -388,6 +393,42 @@ mod tests {
 
         let sanitized: serde_json::Value = serde_json::from_slice(&result).unwrap();
         assert_eq!(sanitized["model"], "gpt-4");
+    }
+
+    #[test]
+    fn test_matched_stop_reason_is_preserved() {
+        // vLLM/sglang put the matched stop sequence at choices[].stop_reason;
+        // sanitization must keep it so downstream translation can read it.
+        let sanitizer = ResponseSanitizer {
+            original_model: Some("m".to_string()),
+        };
+        let response_json = r#"{
+            "id": "c", "object": "chat.completion", "created": 1, "model": "m",
+            "choices": [{
+                "index": 0,
+                "message": { "role": "assistant", "content": "one two" },
+                "finish_reason": "stop",
+                "stop_reason": "three"
+            }]
+        }"#;
+        let result = sanitizer
+            .sanitize("/v1/chat/completions", &HeaderMap::new(), response_json.as_bytes())
+            .unwrap()
+            .unwrap();
+        let sanitized: serde_json::Value = serde_json::from_slice(&result).unwrap();
+        assert_eq!(sanitized["choices"][0]["stop_reason"], "three");
+
+        // A response without it does not gain a spurious null field.
+        let plain = r#"{
+            "id": "c", "object": "chat.completion", "created": 1, "model": "m",
+            "choices": [{ "index": 0, "message": { "role": "assistant", "content": "hi" }, "finish_reason": "stop" }]
+        }"#;
+        let result = sanitizer
+            .sanitize("/v1/chat/completions", &HeaderMap::new(), plain.as_bytes())
+            .unwrap()
+            .unwrap();
+        let sanitized: serde_json::Value = serde_json::from_slice(&result).unwrap();
+        assert!(sanitized["choices"][0].get("stop_reason").is_none());
     }
 
     #[test]

--- a/src/strict/mod.rs
+++ b/src/strict/mod.rs
@@ -174,6 +174,13 @@ pub fn build_strict_router<T: HttpClient + Clone + Send + Sync + 'static>(
             "/chat/completions",
             post(handlers::chat_completions_handler::<T>),
         )
+        // Anthropic Messages ingress alias. Foreign-protocol translation happens
+        // at the dwctl edge (the request body is already Chat Completions and the
+        // path is normalised to `/chat/completions` by the time it reaches here);
+        // this alias only exists so strict-mode routing matches `/messages` and
+        // dispatches to the chat-completions handler. No Anthropic logic lives in
+        // onwards. Non-strict mode needs no alias (its catch-all already matches).
+        .route("/messages", post(handlers::chat_completions_handler::<T>))
         // Legacy text completions
         .route("/completions", post(handlers::completions_handler::<T>))
         // Open Responses
@@ -317,6 +324,27 @@ mod tests {
             .uri("/chat/completions")
             .header("content-type", "application/json")
             .body(Body::from(padded_chat_completions_body(3 * 1024 * 1024)))
+            .unwrap();
+
+        let response = router.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_strict_router_messages_alias_routes_to_chat_completions() {
+        // The Anthropic ingress alias: a (already edge-translated) Chat
+        // Completions body posted to `/messages` must route to the
+        // chat-completions handler, exactly like `/chat/completions`. Foreign
+        // translation and path normalisation happen upstream at the dwctl edge;
+        // onwards just needs the route to match.
+        let state = create_test_app_state();
+        let router = build_strict_router(state);
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/messages")
+            .header("content-type", "application/json")
+            .body(Body::from(padded_chat_completions_body(16)))
             .unwrap();
 
         let response = router.oneshot(request).await.unwrap();


### PR DESCRIPTION
## Summary

Two small changes that support the dwctl Anthropic Messages ingress. There is zero Anthropic logic in onwards.

1. Adds a `/messages` route to the strict router, aliased to the existing `chat_completions_handler`, so a dwctl-edge-translated Anthropic request can route through the unchanged chat pipeline. The request body is already Chat Completions (and the path is normalised to `/chat/completions`) by the time it reaches here. Non-strict mode needs no change: its catch-all `/{*path}` already matches `/messages`.

2. Preserves `choices[].stop_reason` through the strict response sanitizer. vLLM / sglang report the matched stop sequence there; the sanitizer previously dropped it as an unknown field. Keeping it lets the dwctl edge surface Anthropic's `stop_sequence`. The value is only ever a client-supplied stop string or a token id, so nothing sensitive is exposed; it is omitted when absent.

## Why

Anthropic and OpenAI are the two dominant API shapes, and we only accept one today. dwctl is adding an Anthropic Messages ingress so customers on the Anthropic SDK or Anthropic-targeted tooling (Claude Code) can point at our gateway with a base-URL change. The translation lives at the dwctl edge so it can reuse the existing pipeline (image normalisation, tool injection, logging, billing); this alias is the one small onwards change that lets a `/messages` request reach the chat-completions handler.

## Changes

- `src/strict/mod.rs`: `.route("/messages", post(chat_completions_handler))` in `build_strict_router`, with a comment explaining the alias.
- `src/response_sanitizer.rs`: add `stop_reason` as a preserved field on `LenientChoice` (kept through serialization rather than dropped with the unknown-field catch-all).
- Tests: `test_strict_router_messages_alias_routes_to_chat_completions` (a Chat Completions body posted to `/messages` routes to the chat-completions handler and returns 200, like `/chat/completions`) and `test_matched_stop_reason_is_preserved` (a choice carrying `stop_reason` survives sanitization, and a choice without one gains no spurious field).

## Test plan

- [ ] `cargo test --lib strict:: response_sanitizer::` passes, including the new tests.
- [ ] `just lint rust` passes.

## Notes

- This is the onwards half of the Anthropic ingress work. It should be released first; the dwctl PR then bumps the onwards dependency to pick it up.