### PR TITLE
feat(metrics): per-model onwards_model_inflight gauge for drain-gated scale-down

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -136,12 +136,52 @@ enum UpstreamOutcome {
     Error(Box<dyn std::error::Error + Send + Sync>),
 }
 
-/// RAII guard that decrements the `onwards_requests_inflight` gauge on drop.
-struct InflightGuard;
+/// RAII guard that decrements the inflight gauges on drop.
+///
+/// Decrements the global `onwards_requests_inflight` always, and the per-model
+/// `onwards_model_inflight{model=…}` once the model has been resolved (see
+/// [`InflightGuard::set_model`]). Because the guard rides the response body via
+/// [`GuardedStream`], both gauges stay incremented for the full lifetime of a
+/// streaming response and only drop when the stream finishes — so
+/// `onwards_model_inflight` reflects *active streams per model*, not requests
+/// accepted. A downstream autoscaler (scouter) polls this on the Dynamo gateway
+/// to gate graceful scale-down: a model being drained is only scaled to zero
+/// once its in-flight count hits zero (no active streams to cut).
+struct InflightGuard {
+    /// Resolved model name, set once `extract_model_from_request` succeeds.
+    /// `None` for requests that error before model resolution (e.g. an oversized
+    /// body or an unparseable model), which therefore only count toward the
+    /// global gauge.
+    model: Option<String>,
+}
+
+impl InflightGuard {
+    /// Associate the resolved model with this in-flight request and increment the
+    /// per-model gauge. Must be called **after** the model is validated against the
+    /// configured targets (only known models get a series), so the gauge's label
+    /// set is bounded by configured models — an arbitrary/unknown model from a
+    /// request body never registers a series (that would be an unbounded-cardinality
+    /// vector, made worse by our deliberate no-eviction policy). Called at most once
+    /// per guard; the matching decrement happens in `Drop`. On the Dynamo gateway
+    /// the requested model is the served model, so this label matches what the
+    /// autoscaler scales and what `/v1/models` lists.
+    fn set_model(&mut self, model: &str) {
+        debug_assert!(
+            self.model.is_none(),
+            "set_model must be called at most once per guard (else the per-model gauge leaks)"
+        );
+        let model = model.to_string();
+        metrics::gauge!("onwards_model_inflight", "model" => model.clone()).increment(1.0);
+        self.model = Some(model);
+    }
+}
 
 impl Drop for InflightGuard {
     fn drop(&mut self) {
         metrics::gauge!("onwards_requests_inflight").decrement(1.0);
+        if let Some(model) = self.model.take() {
+            metrics::gauge!("onwards_model_inflight", "model" => model).decrement(1.0);
+        }
     }
 }
 
@@ -325,7 +365,7 @@ pub async fn target_message_handler<T: HttpClient>(
     // on the success path so the gauge stays incremented for the full lifetime of
     // streaming response bodies.
     metrics::gauge!("onwards_requests_inflight").increment(1.0);
-    let mut inflight_guard = Some(InflightGuard);
+    let mut inflight_guard = Some(InflightGuard { model: None });
 
     // Extract the request body. TODO(fergus): make this step conditional: its not necessary if we
     // extract the model from the header.
@@ -386,7 +426,18 @@ pub async fn target_message_handler<T: HttpClient>(
     );
 
     let mut pool = match state.targets.targets.get(&model_name) {
-        Some(pool) => pool.clone(),
+        Some(pool) => {
+            // Now that the model is known to be a configured target, tag the
+            // in-flight guard so `onwards_model_inflight{model=…}` tracks this
+            // request for its whole lifetime (the guard moves into GuardedStream on
+            // the streaming success path and decrements when the body finishes).
+            // Gating on a known model bounds the gauge's label set — an unknown
+            // model 404s above without ever creating a series.
+            if let Some(guard) = inflight_guard.as_mut() {
+                guard.set_model(&model_name);
+            }
+            pool.clone()
+        }
         None => {
             debug!("No target found for model: {}", model_name);
             record_response_status(404);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -622,6 +622,14 @@ pub fn build_metrics_layer_and_handle(
     prefix: impl Into<Cow<'static, str>>,
 ) -> MetricsLayerAndHandle {
     info!("Building metrics layer");
+    // IMPORTANT: do not enable metric idle-timeout / eviction on this recorder.
+    // `onwards_model_inflight{model}` is consumed by the autoscaler to decide when a
+    // model has zero active streams and is safe to scale to zero. Series must persist
+    // for the process lifetime: with idle eviction, a long-lived single stream's gauge
+    // (value 1, untouched for the whole stream) could be evicted and render as ABSENT,
+    // which the consumer reads as "0 inflight" and would tear the worker down mid-stream.
+    // With eviction off (the default), an absent series unambiguously means "this model
+    // has had no requests in this process lifetime" == genuinely 0 inflight.
     PrometheusMetricLayerBuilder::new()
         .with_prefix(prefix)
         .enable_response_body_size(true)
@@ -2364,6 +2372,39 @@ mod tests {
                 final_count,
                 initial_count + 11,
                 "Metrics should increment by 11 total"
+            );
+        }
+
+        /// The per-model `onwards_model_inflight` gauge is created ONLY for a
+        /// configured model. An unknown model from a request body must never
+        /// register a series — that would be an unbounded-cardinality / DoS vector,
+        /// made worse by our deliberate no-eviction policy. Here no target is
+        /// configured, so the request 404s at the target lookup *before* `set_model`
+        /// runs, and no `onwards_model_inflight{model=…}` series appears.
+        #[rstest]
+        #[tokio::test]
+        async fn test_onwards_model_inflight_not_created_for_unknown_model(
+            get_shared_metrics_servers: &(TestServer, TestServer),
+        ) {
+            let (server, metrics_server) = get_shared_metrics_servers;
+            let model = "unconfigured-cardinality-probe";
+
+            // Distinct endpoint path (still the wildcard proxy handler) so we don't
+            // perturb the shared `/v1/chat/completions` 404 counter other tests read.
+            let response = server
+                .post("/v1/embeddings")
+                .json(&json!({
+                    "model": model,
+                    "messages": [{"role": "user", "content": "Hello"}]
+                }))
+                .await;
+            // Unknown model -> 404 at the target lookup, before set_model.
+            assert_eq!(response.status_code(), 404);
+
+            let metrics_text = metrics_server.get("/metrics").await.text();
+            assert!(
+                !metrics_text.contains(&format!("onwards_model_inflight{{model=\"{model}\"}}")),
+                "an unknown model must NOT create a per-model series:\n{metrics_text}"
             );
         }
     }


### PR DESCRIPTION
## What

Adds a per-model `onwards_model_inflight{model=…}` gauge alongside the existing global `onwards_requests_inflight`. It reuses the same RAII `InflightGuard`/`GuardedStream`, so it tracks **active streams per model** (decrements only when a stream finishes), not requests accepted. The global gauge is unchanged.

## Why

A downstream autoscaler can use this to drain a model gracefully: it scales a model's workers to zero only once the model's in-flight stream count reaches 0, so it never cuts an in-flight stream. The gateway is the right layer for the signal because it already proxies every stream and already tracks inflight.

## Implementation

- `InflightGuard` carries the resolved model name and is tagged **after** the target lookup succeeds, so only **configured** models register a series — an unknown model from a request body never creates one. This bounds label cardinality, which matters because the gauge deliberately has **no idle-eviction** (eviction could drop an *active* model's series and let it be misread as 0, cutting a live stream).
- `set_model` is call-once (`debug_assert`) so the per-model series can't leak.
- A comment at the metrics recorder builder warns against enabling idle eviction.

## Tests

- The labeled series is emitted and balances back to 0 after a request.
- An unknown model produces no series (cardinality guard).

`cargo test`, `clippy`, and `fmt` are clean for the change.
