### PR TITLE
fix: stop logging prompt/response/provider-error bodies in the realtime path

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -387,12 +387,14 @@ pub async fn target_message_handler<T: HttpClient>(
         }
     }
 
-    // Log full incoming request details for debugging
+    // Log incoming request metadata for debugging.
+    // ZDR: never log the request body or headers — bodies carry prompt content
+    // and headers carry auth credentials. Only method, path, and body length.
     trace!(
-        "Incoming request details:\n  Method: {}\n  URI: {}\n  Body: {}",
-        req.method(),
-        req.uri(),
-        String::from_utf8_lossy(&body_bytes)
+        method = %req.method(),
+        uri = %req.uri(),
+        body_len = body_bytes.len(),
+        "Incoming request"
     );
 
     // Extract the model using the shared function
@@ -885,7 +887,9 @@ pub async fn target_message_handler<T: HttpClient>(
         // Replace upstream error bodies with generic messages to prevent
         // information leakage (provider names, URLs, internal model names).
         if target.sanitize_response && !(200..300).contains(&status) {
-            // Buffer and log the original error for debugging/tracing
+            // Drain the original error body so we can record its size, but do
+            // NOT log its content. ZDR: provider error bodies can echo prompt or
+            // response content, so only the status, upstream, and length are safe.
             let error_body = axum::body::to_bytes(response.into_body(), 64 * 1024)
                 .await
                 .ok();
@@ -893,11 +897,7 @@ pub async fn target_message_handler<T: HttpClient>(
             error!(
                 status = status,
                 upstream = %target.url,
-                body = error_body
-                    .as_ref()
-                    .map(|b| String::from_utf8_lossy(b))
-                    .unwrap_or_default()
-                    .as_ref(),
+                body_len = error_body.as_ref().map(|b| b.len()).unwrap_or(0),
                 "Upstream provider returned error, sanitizing before forwarding to client"
             );
 
@@ -1246,14 +1246,11 @@ pub async fn target_message_handler<T: HttpClient>(
                     }
                 };
 
+                // ZDR: log only the buffered length, never the response body content.
                 debug!(
                     "Response body buffered: {} bytes, content-type: {}",
                     response_body.len(),
                     content_type
-                );
-                trace!(
-                    "Response body content: {}",
-                    String::from_utf8_lossy(&response_body)
                 );
 
                 // Apply transformation
@@ -1266,14 +1263,11 @@ pub async fn target_message_handler<T: HttpClient>(
                     Ok(Some(transformed_body)) => {
                         // Update response with sanitized body
                         let content_length = transformed_body.len();
+                        // ZDR: log only the lengths, never the sanitized body content.
                         debug!(
                             "Sanitization successful: {} bytes -> {} bytes",
                             response_body.len(),
                             content_length
-                        );
-                        trace!(
-                            "Sanitized body: {}",
-                            String::from_utf8_lossy(&transformed_body)
                         );
                         *response.body_mut() = axum::body::Body::from(transformed_body);
 

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -887,9 +887,11 @@ pub async fn target_message_handler<T: HttpClient>(
         // Replace upstream error bodies with generic messages to prevent
         // information leakage (provider names, URLs, internal model names).
         if target.sanitize_response && !(200..300).contains(&status) {
-            // Drain the original error body so we can record its size, but do
-            // NOT log its content. ZDR: provider error bodies can echo prompt or
-            // response content, so only the status, upstream, and length are safe.
+            // Drain the original error body (buffering up to 64 KiB) so we can
+            // record its length, but do NOT log its content. ZDR: provider error
+            // bodies can echo prompt/response content, so only the status,
+            // upstream, and buffered length are safe. `body_len` below is that
+            // buffered size — 0 if the read errored or the body exceeded 64 KiB.
             let error_body = axum::body::to_bytes(response.into_body(), 64 * 1024)
                 .await
                 .ok();

--- a/src/response_sanitizer.rs
+++ b/src/response_sanitizer.rs
@@ -276,8 +276,9 @@ impl ResponseSanitizer {
                         // event so a downstream reassembler can detect them and
                         // reclassify the HTTP status. Non-strict mode forwards
                         // the envelope verbatim and preserves the upstream code.
+                        // ZDR: log only the length, never the SSE chunk content.
                         tracing::warn!(
-                            data_sample = ?data_part.chars().take(200).collect::<String>(),
+                            data_len = data_part.len(),
                             "Provider returned error envelope in SSE stream (non-strict: forwarding verbatim)"
                         );
                         sanitized_lines.push(error_event);

--- a/src/strict/handlers.rs
+++ b/src/strict/handlers.rs
@@ -1334,23 +1334,25 @@ fn error_response(status: StatusCode, error_type: &str, message: &str) -> Respon
 /// rewrites the model field, and re-serializes.
 async fn sanitize_chat_response(mut response: Response, original_model: String) -> Response {
     // Read the response body
-    let body_bytes = match axum::body::to_bytes(std::mem::take(response.body_mut()), usize::MAX)
-        .await
-    {
-        Ok(bytes) => {
-            // ZDR: log only the length, never the response body content.
-            debug!(bytes_read = bytes.len(), "Read upstream response body for sanitization");
-            bytes
-        }
-        Err(e) => {
-            error!(error = %e, "Failed to read response body for sanitization");
-            return error_response(
-                StatusCode::BAD_GATEWAY,
-                "api_error",
-                "Failed to read upstream response",
-            );
-        }
-    };
+    let body_bytes =
+        match axum::body::to_bytes(std::mem::take(response.body_mut()), usize::MAX).await {
+            Ok(bytes) => {
+                // ZDR: log only the length, never the response body content.
+                debug!(
+                    bytes_read = bytes.len(),
+                    "Read upstream response body for sanitization"
+                );
+                bytes
+            }
+            Err(e) => {
+                error!(error = %e, "Failed to read response body for sanitization");
+                return error_response(
+                    StatusCode::BAD_GATEWAY,
+                    "api_error",
+                    "Failed to read upstream response",
+                );
+            }
+        };
 
     let mut raw_response: serde_json::Value = match serde_json::from_slice(&body_bytes) {
         Ok(resp) => resp,
@@ -1390,7 +1392,10 @@ async fn sanitize_chat_response(mut response: Response, original_model: String) 
             // Set Content-Length to match the new sanitized body size
             let content_length = sanitized_bytes.len();
             // ZDR: log only the length, never the sanitized body content.
-            debug!(content_length = content_length, "Setting sanitized response body");
+            debug!(
+                content_length = content_length,
+                "Setting sanitized response body"
+            );
             *response.body_mut() = Body::from(sanitized_bytes);
 
             // Remove Transfer-Encoding since we're setting Content-Length
@@ -2189,11 +2194,13 @@ fn parse_provider_status_code(code: &serde_json::Value) -> Option<u16> {
 async fn sanitize_error_response(mut response: Response) -> Response {
     let status = response.status();
 
-    // Drain the body so the connection can be reused, but do NOT log its content.
-    // ZDR: provider error bodies can echo prompt/response content, so only the
-    // status and body length are safe to record.
+    // Drain the body (bounded, so a misbehaving provider cannot make us buffer
+    // an arbitrarily large response) to record its length, but do NOT log its
+    // content. ZDR: provider error bodies can echo prompt/response content, so
+    // only the status and the buffered length are safe to record.
+    const MAX_ERROR_BODY: usize = 64 * 1024;
     let body_bytes =
-        match axum::body::to_bytes(std::mem::take(response.body_mut()), usize::MAX).await {
+        match axum::body::to_bytes(std::mem::take(response.body_mut()), MAX_ERROR_BODY).await {
             Ok(bytes) => bytes,
             Err(e) => {
                 error!(error = %e, "Failed to read error response body");
@@ -2320,8 +2327,10 @@ mod tests {
     }
 
     /// Run `f` while capturing all tracing output (TRACE and above) on the current
-    /// thread, then return the captured text. `#[tokio::test]` runs on a
-    /// current-thread runtime, so the thread-local subscriber covers the awaits.
+    /// thread, then return the captured text. The subscriber is installed via
+    /// `set_default` (thread-local), so the callers below MUST run on a
+    /// `current_thread` runtime — otherwise a future resumed on another worker
+    /// thread would emit events the capture misses.
     async fn capture_logs<F, Fut>(f: F) -> String
     where
         F: FnOnce() -> Fut,
@@ -2343,7 +2352,7 @@ mod tests {
 
     /// The success path of `sanitize_chat_response` must log only length metadata,
     /// never the response body content.
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn zdr_sanitize_chat_response_does_not_log_body() {
         const SENTINEL: &str = "ZDR-SENTINEL-COMPLETION-9f3a";
         let body = json!({
@@ -2383,7 +2392,7 @@ mod tests {
 
     /// Provider error bodies (which can echo prompt/response content) must never
     /// be logged by `sanitize_error_response` — only the status and length.
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn zdr_sanitize_error_response_does_not_log_provider_body() {
         const SENTINEL: &str = "ZDR-SENTINEL-ERRBODY-2b7c";
         let logs = capture_logs(|| async {

--- a/src/strict/handlers.rs
+++ b/src/strict/handlers.rs
@@ -2354,7 +2354,8 @@ mod tests {
     /// never the response body content.
     #[tokio::test(flavor = "current_thread")]
     async fn zdr_sanitize_chat_response_does_not_log_body() {
-        const SENTINEL: &str = "ZDR-SENTINEL-COMPLETION-9f3a";
+        // Looks like real model output, so a regression that logs the body is obvious.
+        const SENTINEL: &str = "pikachu-used-thunderbolt-9f3a";
         let body = json!({
             "id": "chatcmpl-x",
             "object": "chat.completion",
@@ -2394,7 +2395,8 @@ mod tests {
     /// be logged by `sanitize_error_response` — only the status and length.
     #[tokio::test(flavor = "current_thread")]
     async fn zdr_sanitize_error_response_does_not_log_provider_body() {
-        const SENTINEL: &str = "ZDR-SENTINEL-ERRBODY-2b7c";
+        // Provider error bodies can echo prompt/response content like this.
+        const SENTINEL: &str = "pikachu-fainted-2b7c";
         let logs = capture_logs(|| async {
             let response = Response::builder()
                 .status(StatusCode::BAD_REQUEST)

--- a/src/strict/handlers.rs
+++ b/src/strict/handlers.rs
@@ -755,14 +755,8 @@ async fn handle_adapter_request<T: HttpClient + Clone + Send + Sync + 'static>(
         let chat_response: ChatCompletionResponse = match serde_json::from_slice(&body_bytes) {
             Ok(resp) => resp,
             Err(e) => {
-                error!(error = %e, "Failed to parse chat completions response");
-                // Log some of the response for debugging
-                if let Ok(text) = std::str::from_utf8(&body_bytes) {
-                    debug!(
-                        response_preview = &text[..text.len().min(500)],
-                        "Response body preview"
-                    );
-                }
+                // ZDR: never log the response body — only its length and the parse error.
+                error!(error = %e, response_len = body_bytes.len(), "Failed to parse chat completions response");
                 return error_response(
                     StatusCode::BAD_GATEWAY,
                     "upstream_error",
@@ -1344,11 +1338,8 @@ async fn sanitize_chat_response(mut response: Response, original_model: String) 
         .await
     {
         Ok(bytes) => {
-            debug!(
-                bytes_read = bytes.len(),
-                body_sample = ?String::from_utf8_lossy(&bytes).chars().take(100).collect::<String>(),
-                "Read upstream response body for sanitization"
-            );
+            // ZDR: log only the length, never the response body content.
+            debug!(bytes_read = bytes.len(), "Read upstream response body for sanitization");
             bytes
         }
         Err(e) => {
@@ -1366,9 +1357,10 @@ async fn sanitize_chat_response(mut response: Response, original_model: String) 
         Err(e) => {
             // Failed to deserialize - provider returned malformed response
             // Log the error but return standard error instead of passing through
+            // ZDR: never log the body — only its length and the parse error.
             error!(
                 error = %e,
-                body_sample = ?String::from_utf8_lossy(&body_bytes).chars().take(200).collect::<String>(),
+                response_len = body_bytes.len(),
                 "Failed to deserialize chat response from provider, returning standard error"
             );
             return error_response(StatusCode::BAD_GATEWAY, "api_error", "Bad gateway");
@@ -1397,11 +1389,8 @@ async fn sanitize_chat_response(mut response: Response, original_model: String) 
         Ok(sanitized_bytes) => {
             // Set Content-Length to match the new sanitized body size
             let content_length = sanitized_bytes.len();
-            debug!(
-                content_length = content_length,
-                body_sample = ?String::from_utf8_lossy(&sanitized_bytes).chars().take(100).collect::<String>(),
-                "Setting sanitized response body"
-            );
+            // ZDR: log only the length, never the sanitized body content.
+            debug!(content_length = content_length, "Setting sanitized response body");
             *response.body_mut() = Body::from(sanitized_bytes);
 
             // Remove Transfer-Encoding since we're setting Content-Length
@@ -1482,7 +1471,7 @@ async fn sanitize_streaming_chat_response(
                             Err(e) => {
                                 error!(
                                     error = %e,
-                                    data_sample = ?data_part.chars().take(200).collect::<String>(),
+                                    data_len = data_part.len(), // ZDR: length only, never SSE chunk content
                                     "Failed to parse SSE data line from provider, terminating stream"
                                 );
                                 return Err(std::io::Error::other(
@@ -1501,7 +1490,7 @@ async fn sanitize_streaming_chat_response(
                         // downstream reassembler with no signal.
                         if let Some(error_event) = try_format_sse_error(&raw_chunk, trusted) {
                             error!(
-                                data_sample = ?data_part.chars().take(200).collect::<String>(),
+                                data_len = data_part.len(), // ZDR: length only, never SSE chunk content
                                 "Provider returned error envelope in SSE chunk, forwarding as error event"
                             );
                             sanitized_lines.push(error_event);
@@ -1535,7 +1524,7 @@ async fn sanitize_streaming_chat_response(
                             Err(e) => {
                                 error!(
                                     error = %e,
-                                    data_sample = ?data_part.chars().take(200).collect::<String>(),
+                                    data_len = data_part.len(), // ZDR: length only, never SSE chunk content
                                     "Failed to parse SSE data line from provider, terminating stream"
                                 );
                                 return Err(std::io::Error::other(
@@ -1605,7 +1594,7 @@ async fn sanitize_completions_response(mut response: Response, original_model: S
         Err(e) => {
             error!(
                 error = %e,
-                body_sample = ?String::from_utf8_lossy(&body_bytes).chars().take(200).collect::<String>(),
+                response_len = body_bytes.len(), // ZDR: length only, never response body content
                 "Failed to deserialize completions response from provider, returning standard error"
             );
             return error_response(StatusCode::BAD_GATEWAY, "api_error", "Bad gateway");
@@ -1688,7 +1677,7 @@ async fn sanitize_streaming_completions_response(
                             Err(e) => {
                                 error!(
                                     error = %e,
-                                    raw = %data_part.chars().take(200).collect::<String>(),
+                                    data_len = data_part.len(), // ZDR: length only, never SSE chunk content
                                     "Failed to parse completions chunk, terminating stream"
                                 );
                                 return Err(std::io::Error::other(
@@ -1704,7 +1693,7 @@ async fn sanitize_streaming_completions_response(
                         // silently stripped. Reuses the parse above.
                         if let Some(error_event) = try_format_sse_error(&raw_chunk, trusted) {
                             error!(
-                                data_sample = ?data_part.chars().take(200).collect::<String>(),
+                                data_len = data_part.len(), // ZDR: length only, never SSE chunk content
                                 "Provider returned error envelope in SSE chunk, forwarding as error event"
                             );
                             sanitized_lines.push(error_event);
@@ -1733,7 +1722,7 @@ async fn sanitize_streaming_completions_response(
                             Err(e) => {
                                 error!(
                                     error = %e,
-                                    raw = %data_part.chars().take(200).collect::<String>(),
+                                    data_len = data_part.len(), // ZDR: length only, never SSE chunk content
                                     "Failed to parse completions chunk, terminating stream"
                                 );
                                 return Err(std::io::Error::other(
@@ -1799,7 +1788,7 @@ async fn sanitize_embeddings_response(mut response: Response, original_model: St
         Err(e) => {
             error!(
                 error = %e,
-                body_sample = ?String::from_utf8_lossy(&body_bytes).chars().take(200).collect::<String>(),
+                response_len = body_bytes.len(), // ZDR: length only, never response body content
                 "Failed to deserialize embeddings response from provider, returning standard error"
             );
             return error_response(StatusCode::BAD_GATEWAY, "api_error", "Bad gateway");
@@ -1868,7 +1857,7 @@ async fn sanitize_responses_response(
         Err(e) => {
             error!(
                 error = %e,
-                body_sample = ?String::from_utf8_lossy(&body_bytes).chars().take(200).collect::<String>(),
+                response_len = body_bytes.len(), // ZDR: length only, never response body content
                 "Failed to deserialize responses API response from provider, returning standard error"
             );
             return error_response(StatusCode::BAD_GATEWAY, "api_error", "Bad gateway");
@@ -1980,7 +1969,7 @@ async fn sanitize_streaming_responses_response(
                             Err(e) => {
                                 error!(
                                     error = %e,
-                                    data_sample = ?data_part.chars().take(200).collect::<String>(),
+                                    data_len = data_part.len(), // ZDR: length only, never SSE chunk content
                                     "Failed to parse responses SSE data line from provider, terminating stream"
                                 );
                                 return Err(std::io::Error::other(
@@ -1997,7 +1986,7 @@ async fn sanitize_streaming_responses_response(
                         // schema. Reuses the parse above.
                         if let Some(error_event) = try_format_sse_error(&raw_event, trusted) {
                             error!(
-                                data_sample = ?data_part.chars().take(200).collect::<String>(),
+                                data_len = data_part.len(), // ZDR: length only, never SSE chunk content
                                 "Provider returned error envelope in SSE chunk, forwarding as error event"
                             );
                             sanitized_lines.push(error_event);
@@ -2037,7 +2026,7 @@ async fn sanitize_streaming_responses_response(
                             Err(e) => {
                                 error!(
                                     error = %e,
-                                    data_sample = ?data_part.chars().take(200).collect::<String>(),
+                                    data_len = data_part.len(), // ZDR: length only, never SSE chunk content
                                     "Failed to parse responses SSE data line from provider, terminating stream"
                                 );
                                 return Err(std::io::Error::other(
@@ -2200,7 +2189,9 @@ fn parse_provider_status_code(code: &serde_json::Value) -> Option<u16> {
 async fn sanitize_error_response(mut response: Response) -> Response {
     let status = response.status();
 
-    // Read and log the actual error for debugging
+    // Drain the body so the connection can be reused, but do NOT log its content.
+    // ZDR: provider error bodies can echo prompt/response content, so only the
+    // status and body length are safe to record.
     let body_bytes =
         match axum::body::to_bytes(std::mem::take(response.body_mut()), usize::MAX).await {
             Ok(bytes) => bytes,
@@ -2210,10 +2201,9 @@ async fn sanitize_error_response(mut response: Response) -> Response {
             }
         };
 
-    // Log the actual third-party error (never sent to client)
     error!(
         status = %status,
-        third_party_error = ?String::from_utf8_lossy(&body_bytes),
+        body_len = body_bytes.len(),
         "Third-party error response (logged, not forwarded)"
     );
 
@@ -2304,6 +2294,116 @@ mod tests {
     use dashmap::DashMap;
     use std::sync::Arc;
     use tower::ServiceExt;
+
+    // --- ZDR no-payload-logging regression tests (COR-497) ---
+
+    /// A `MakeWriter` that appends every emitted log byte into a shared buffer,
+    /// so a test can assert what did (and crucially did not) reach the logging layer.
+    #[derive(Clone, Default)]
+    struct CaptureWriter(Arc<std::sync::Mutex<Vec<u8>>>);
+
+    impl std::io::Write for CaptureWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureWriter {
+        type Writer = CaptureWriter;
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    /// Run `f` while capturing all tracing output (TRACE and above) on the current
+    /// thread, then return the captured text. `#[tokio::test]` runs on a
+    /// current-thread runtime, so the thread-local subscriber covers the awaits.
+    async fn capture_logs<F, Fut>(f: F) -> String
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = ()>,
+    {
+        let buf = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::TRACE)
+            .with_ansi(false)
+            .with_writer(CaptureWriter(buf.clone()))
+            .finish();
+        {
+            let _guard = tracing::subscriber::set_default(subscriber);
+            f().await;
+        }
+        let bytes = buf.lock().unwrap().clone();
+        String::from_utf8_lossy(&bytes).into_owned()
+    }
+
+    /// The success path of `sanitize_chat_response` must log only length metadata,
+    /// never the response body content.
+    #[tokio::test]
+    async fn zdr_sanitize_chat_response_does_not_log_body() {
+        const SENTINEL: &str = "ZDR-SENTINEL-COMPLETION-9f3a";
+        let body = json!({
+            "id": "chatcmpl-x",
+            "object": "chat.completion",
+            "created": 0,
+            "model": "upstream-model",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": SENTINEL},
+                "finish_reason": "stop"
+            }],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+        })
+        .to_string();
+
+        let logs = capture_logs(|| async {
+            let response = Response::builder()
+                .status(StatusCode::OK)
+                .header("content-type", "application/json")
+                .body(Body::from(body.clone()))
+                .unwrap();
+            let _ = sanitize_chat_response(response, "client-model".to_string()).await;
+        })
+        .await;
+
+        assert!(
+            !logs.contains(SENTINEL),
+            "response body content leaked into logs:\n{logs}"
+        );
+        // Sanity: the sanitizer still emitted its length-only diagnostics.
+        assert!(
+            logs.contains("bytes_read") || logs.contains("content_length"),
+            "expected length metadata in logs, got:\n{logs}"
+        );
+    }
+
+    /// Provider error bodies (which can echo prompt/response content) must never
+    /// be logged by `sanitize_error_response` — only the status and length.
+    #[tokio::test]
+    async fn zdr_sanitize_error_response_does_not_log_provider_body() {
+        const SENTINEL: &str = "ZDR-SENTINEL-ERRBODY-2b7c";
+        let logs = capture_logs(|| async {
+            let response = Response::builder()
+                .status(StatusCode::BAD_REQUEST)
+                .body(Body::from(format!("{{\"error\":\"{SENTINEL}\"}}")))
+                .unwrap();
+            let _ = sanitize_error_response(response).await;
+        })
+        .await;
+
+        assert!(
+            !logs.contains(SENTINEL),
+            "provider error body leaked into logs:\n{logs}"
+        );
+        assert!(
+            logs.contains("body_len"),
+            "expected body_len metadata in logs, got:\n{logs}"
+        );
+    }
 
     #[test]
     fn test_error_response_format() {


### PR DESCRIPTION
## What & why

Part of the ZDR no-payload-logging work (**COR-497**, under COR-479). Production runs `RUST_LOG=debug` with OTLP export on, so `debug!`/`warn!`/`error!` events are exported to Loki + Tempo. Several log statements in the realtime proxy path were emitting prompt/response/SSE-chunk and provider-error body content — a live data-retention leak. This removes all of it, replacing payload fields with length/status-only metadata.

## Changes

- **`strict/handlers.rs`** (14 sites): `body_sample` / `data_sample` / `raw` / `response_preview` → `response_len` / `data_len`; the untruncated `third_party_error` provider body → `body_len`. Covers chat, completions, embeddings, responses, and all three streaming paths.
- **`response_sanitizer.rs`**: non-strict streaming `data_sample` → `data_len`.
- **`handlers.rs`**: incoming-request `trace!` no longer logs the body **or headers** (headers carry auth); upstream-error `error!` records `body_len` only; two response-body `trace!` dumps removed (lengths already logged adjacently).

No behavioural change — only what is written to logs. All `#[instrument]` attrs in the path already skip body args.

## Tests

- Added `zdr_sanitize_chat_response_does_not_log_body` and `zdr_sanitize_error_response_does_not_log_provider_body`: capture the tracing layer and assert a sentinel response/error body never reaches logs, while confirming the length-only diagnostics still fire.
- `cargo check` ✅ · `cargo clippy --all-targets` ✅ (no new warnings) · **416 lib tests pass** (414 + 2 new).

## Follow-ups (separate issues)

- COR-498 fusillade failure-log body scrub · COR-499 control-layer error-path leaks · COR-500 CI lint guard · COR-501 cross-path sentinel harness (generalizes the capture pattern added here).