### PR TITLE
chore: align multi-step fusillade dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,8 +978,9 @@ dependencies = [
 
 [[package]]
 name = "fusillade"
-version = "21.0.0"
-source = "git+https://github.com/doublewordai/fusillade?tag=fusillade-v21.0.0#87f4f493a164c94328a0708c41491f3c133aab3b"
+version = "21.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5d04f5b7ddafc991a80fd3e5d4988efaf6af791e3b8ea5557232f462eafdf35"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1011,8 +1012,9 @@ dependencies = [
 
 [[package]]
 name = "fusillade-arsenal"
-version = "1.0.0"
-source = "git+https://github.com/doublewordai/fusillade?tag=fusillade-v21.0.0#87f4f493a164c94328a0708c41491f3c133aab3b"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06df8fb12fcaa31fd34880a656abf9292dbb98ee8d9109164f9295e2f1ffcc6a"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1039,7 +1041,8 @@ dependencies = [
 [[package]]
 name = "fusillade-core"
 version = "1.0.0"
-source = "git+https://github.com/doublewordai/fusillade?tag=fusillade-v21.0.0#87f4f493a164c94328a0708c41491f3c133aab3b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "523273ae988756dd1260bba667af3f078df2e1171d798f3c06655d91052127b8"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,15 +978,16 @@ dependencies = [
 
 [[package]]
 name = "fusillade"
-version = "20.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb6b150ddc665bd22fa4255e9eb07e6267643c7c58077f1138a8056d7c8563f"
+version = "21.0.0"
+source = "git+https://github.com/doublewordai/fusillade?tag=fusillade-v21.0.0#87f4f493a164c94328a0708c41491f3c133aab3b"
 dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
  "dashmap",
  "eventsource-stream",
+ "fusillade-arsenal",
+ "fusillade-core",
  "futures",
  "hostname",
  "humantime",
@@ -999,14 +1000,57 @@ dependencies = [
  "scopeguard",
  "serde",
  "serde_json",
- "sqlx",
- "sqlx-pool-router",
  "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-util",
  "tracing",
  "tracing-opentelemetry",
+ "uuid",
+]
+
+[[package]]
+name = "fusillade-arsenal"
+version = "1.0.0"
+source = "git+https://github.com/doublewordai/fusillade?tag=fusillade-v21.0.0#87f4f493a164c94328a0708c41491f3c133aab3b"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "async-trait",
+ "chrono",
+ "dashmap",
+ "either",
+ "fusillade-core",
+ "futures",
+ "humantime",
+ "metrics",
+ "rand 0.10.1",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "sqlx-pool-router",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "fusillade-core"
+version = "1.0.0"
+source = "git+https://github.com/doublewordai/fusillade?tag=fusillade-v21.0.0#87f4f493a164c94328a0708c41491f3c133aab3b"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "futures",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "thiserror",
+ "tokio",
+ "tracing",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ metrics = "0.24"
 governor = "0.10.1"
 rand = "0.9"
 uuid = { version = "1", features = ["v4"] }
-fusillade = { git = "https://github.com/doublewordai/fusillade", tag = "fusillade-v21.0.0", optional = true }
+fusillade = { version = "21.0.1", optional = true }
 
 [dev-dependencies]
 axum-test = "18.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ metrics = "0.24"
 governor = "0.10.1"
 rand = "0.9"
 uuid = { version = "1", features = ["v4"] }
-fusillade = { version = ">=17.0.2, <21", optional = true }
+fusillade = { git = "https://github.com/doublewordai/fusillade", tag = "fusillade-v21.0.0", optional = true }
 
 [dev-dependencies]
 axum-test = "18.0.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3194,8 +3194,10 @@ mod tests {
             let router = build_router(app_state);
             let server = TestServer::new(router).unwrap();
 
-            // Make multiple requests
-            for _ in 0..20 {
+            // Make enough requests that a 3:1 weighted random pool should
+            // reliably favor the high-weight provider without making the test
+            // expensive.
+            for _ in 0..100 {
                 let response = server
                     .post("/v1/chat/completions")
                     .json(&json!({
@@ -3208,7 +3210,7 @@ mod tests {
             }
 
             let requests = mock_client.get_requests();
-            assert_eq!(requests.len(), 20);
+            assert_eq!(requests.len(), 100);
 
             // Count requests to each provider (URI is the full path, check if it contains the host)
             let high_weight_count = requests


### PR DESCRIPTION
## Summary
- Point the optional `multi-step` Fusillade dependency at the registry `fusillade 21.0.1` split release.
- Refresh the lockfile to resolve `fusillade 21.0.1`, `fusillade-arsenal 1.0.1`, and `fusillade-core 1.0.0` from crates.io.
- Stabilize the weighted-provider load-balancing test by using a larger request sample.

## Verification
- `cargo check --features multi-step`
- `cargo test test_load_balancing_with_weighted_providers`
- `cargo test --all-features`