### PR TITLE
feat: attach ServedBy response extension identifying the serving upstream

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -221,6 +221,21 @@ struct OriginalModel(String);
 #[derive(Clone, Debug)]
 pub(crate) struct ResolvedTrust(pub(crate) bool);
 
+/// Response extension identifying the upstream provider that produced this response.
+///
+/// Set on the success path after final load-balancer selection — i.e. after any
+/// fallback/retry — so it always names the provider that actually completed the
+/// request. Integrators (e.g. request-logging middleware) can read it to attribute
+/// traffic to a concrete upstream without re-deriving the routing decision.
+/// Requests that fail before a provider produces a response carry no `ServedBy`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ServedBy {
+    /// Full URL of the upstream target that served the request.
+    pub url: String,
+    /// The upstream model name after any `onwards_model` rewrite, when configured.
+    pub onwards_model: Option<String>,
+}
+
 /// Resolve whether W3C trace context headers should be propagated to an
 /// upstream provider. The per-provider `propagate_trace_context` overrides;
 /// when unset, defaults to the resolved trusted value (per-provider `trusted`
@@ -1401,6 +1416,10 @@ pub async fn target_message_handler<T: HttpClient>(
         response
             .extensions_mut()
             .insert(ResolvedTrust(resolved_trust));
+        response.extensions_mut().insert(ServedBy {
+            url: target.url.to_string(),
+            onwards_model: target.onwards_model.clone(),
+        });
 
         // Attach the connection guard and inflight guard to the response body so both
         // are decremented when the body stream completes, not when the handler returns.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@ pub mod traits;
 use client::{HttpClient, HyperClient};
 use handlers::{models as models_handler, target_message_handler};
 use models::ExtractedModel;
+pub use handlers::ServedBy;
 #[cfg(feature = "multi-step")]
 pub use response_loop::{LoopConfig, LoopError, UpstreamTarget, run_response_loop};
 #[cfg(feature = "multi-step")]
@@ -1093,6 +1094,63 @@ mod tests {
         // Check that requests were made to the correct URLs
         assert!(requests[0].uri.contains("api.openai.com"));
         assert!(requests[1].uri.contains("api.anthropic.com"));
+    }
+
+    /// The success path must attach a `ServedBy` response extension naming the
+    /// upstream that produced the response, so integrators (request logging,
+    /// billing attribution) can read it in-process. Driven through the router
+    /// as a tower service — extensions don't survive a real HTTP hop, which is
+    /// exactly why the extension (not a header) carries this.
+    #[tokio::test]
+    async fn test_served_by_extension_set_on_success() {
+        use tower::ServiceExt;
+
+        let targets_map = Arc::new(DashMap::new());
+        targets_map.insert(
+            "gpt-4".to_string(),
+            pool(
+                target::Target::builder()
+                    .url("https://api.openai.com".parse().unwrap())
+                    .onwards_model("gpt-4-upstream".to_string())
+                    .build(),
+            ),
+        );
+        let targets = target::Targets {
+            targets: targets_map,
+            key_rate_limiters: Arc::new(DashMap::new()),
+            key_concurrency_limiters: Arc::new(DashMap::new()),
+            key_labels: Arc::new(DashMap::new()),
+            strict_mode: false,
+            http_pool_config: None,
+        };
+        let mock_client = MockHttpClient::new(
+            StatusCode::OK,
+            r#"{"choices": [{"message": {"content": "Hello!"}}]}"#,
+        );
+        let app_state = AppState::with_client(targets, mock_client);
+        let router = build_router(app_state);
+
+        let request = axum::http::Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("content-type", "application/json")
+            .body(axum::body::Body::from(
+                json!({
+                    "model": "gpt-4",
+                    "messages": [{"role": "user", "content": "Hello"}]
+                })
+                .to_string(),
+            ))
+            .unwrap();
+        let response = router.oneshot(request).await.unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let served_by = response
+            .extensions()
+            .get::<handlers::ServedBy>()
+            .expect("success response must carry ServedBy");
+        assert_eq!(served_by.url, "https://api.openai.com/");
+        assert_eq!(served_by.onwards_model.as_deref(), Some("gpt-4-upstream"));
     }
 
     /// Strict-mode `Targets` with one alias backed by a fallback pool of `n`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1147,7 +1147,7 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         let served_by = response
             .extensions()
-            .get::<handlers::ServedBy>()
+            .get::<crate::ServedBy>()
             .expect("success response must carry ServedBy");
         assert_eq!(served_by.url, "https://api.openai.com/");
         assert_eq!(served_by.onwards_model.as_deref(), Some("gpt-4-upstream"));

--- a/src/strict/handlers.rs
+++ b/src/strict/handlers.rs
@@ -950,7 +950,7 @@ async fn handle_adapter_request<T: HttpClient + Clone + Send + Sync + 'static>(
             }
         };
 
-        return Response::builder()
+        let mut converted = Response::builder()
             .status(parts.status)
             .header("content-type", "application/json")
             .body(Body::from(response_bytes))
@@ -961,6 +961,11 @@ async fn handle_adapter_request<T: HttpClient + Clone + Send + Sync + 'static>(
                     "Failed to build response",
                 )
             });
+        // The conversion built a fresh response; carry over the upstream
+        // response's extensions (ServedBy, ResolvedTrust) so integrators can
+        // still attribute which provider served the final iteration.
+        converted.extensions_mut().extend(parts.extensions);
+        return converted;
     }
 }
 
@@ -1207,7 +1212,7 @@ async fn handle_streaming_adapter_request<T: HttpClient + Clone + Send + Sync + 
         }
     };
 
-    Response::builder()
+    let mut converted = Response::builder()
         .status(parts.status)
         .header("content-type", "text/event-stream")
         .header("cache-control", "no-cache")
@@ -1219,7 +1224,13 @@ async fn handle_streaming_adapter_request<T: HttpClient + Clone + Send + Sync + 
                 "server_error",
                 "Failed to build streaming response",
             )
-        })
+        });
+    // The conversion built a fresh response; carry over the first upstream
+    // response's extensions (ServedBy, ResolvedTrust) so integrators can still
+    // attribute the serving provider. Tool-loop follow-ups discard their parts,
+    // so the initial provider stands in for the whole stream.
+    converted.extensions_mut().extend(parts.extensions);
+    converted
 }
 
 /// Forward a validated request to the upstream provider (returns raw response for adapter)


### PR DESCRIPTION
## What

Adds a public `ServedBy` response extension, set in `target_message_handler` on the success path immediately after final provider selection — i.e. after any fallback/retry — so it always names the provider that actually completed the request. It carries:

- `url`: the upstream target URL that served the request
- `onwards_model`: the upstream model name after any `onwards_model` rewrite

## Why

Integrators embedding onwards (request logging / billing attribution) need per-request attribution of which component of a composite model served the traffic — e.g. distinguishing locally-hosted upstreams from external providers. The routing decision is only knowable inside the load-balancer loop; this exposes it in-process via the established response-extension pattern (`ResolvedTrust` uses the same mechanism). Extensions never serialize to the wire, so nothing leaks to clients.

Requests that error before an upstream produces a response carry no `ServedBy`, which is the correct bucket for them.

## Testing

- New `test_served_by_extension_set_on_success` drives the router as a tower service (extensions don't survive a real HTTP hop, so `TestServer` can't assert this) and checks both fields, including the model-rewrite case.
- Full suite: 477 lib + 12 integration tests pass; clippy clean for the new code.