### PR TITLE
fix: served-by attribution follow-ups from review

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -223,11 +223,17 @@ pub(crate) struct ResolvedTrust(pub(crate) bool);
 
 /// Response extension identifying the upstream provider that produced this response.
 ///
-/// Set on the success path after final load-balancer selection — i.e. after any
-/// fallback/retry — so it always names the provider that actually completed the
-/// request. Integrators (e.g. request-logging middleware) can read it to attribute
-/// traffic to a concrete upstream without re-deriving the routing decision.
-/// Requests that fail before a provider produces a response carry no `ServedBy`.
+/// Present whenever an upstream produced the response that reached the client —
+/// including passed-through non-2xx upstream statuses. Set after final
+/// load-balancer selection (i.e. after any fallback/retry), so it names the
+/// provider whose response was returned; its presence means "an upstream
+/// answered", not "the request succeeded" — check the status code for that.
+/// Absent when no upstream produced a response (auth/validation rejections,
+/// exhausted fallbacks, gateway-generated errors). For streaming tool loops the
+/// response is returned before follow-up iterations run, so it names the
+/// provider of the initial iteration. Integrators (e.g. request-logging
+/// middleware) can read it to attribute traffic to a concrete upstream without
+/// re-deriving the routing decision.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ServedBy {
     /// Full URL of the upstream target that served the request.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,9 +66,9 @@ pub mod telemetry;
 pub mod traits;
 
 use client::{HttpClient, HyperClient};
+pub use handlers::ServedBy;
 use handlers::{models as models_handler, target_message_handler};
 use models::ExtractedModel;
-pub use handlers::ServedBy;
 #[cfg(feature = "multi-step")]
 pub use response_loop::{LoopConfig, LoopError, UpstreamTarget, run_response_loop};
 #[cfg(feature = "multi-step")]

--- a/src/strict/handlers.rs
+++ b/src/strict/handlers.rs
@@ -34,7 +34,7 @@ use crate::traits::RequestContext;
 use axum::Json;
 use axum::body::Body;
 use axum::extract::{FromRequest, State};
-use axum::http::{HeaderMap, Request, StatusCode, header};
+use axum::http::{Extensions, HeaderMap, Request, StatusCode, header};
 use axum::response::{IntoResponse, Response};
 use futures_util::StreamExt;
 use http_body_util::BodyExt;
@@ -562,6 +562,16 @@ fn should_use_adapter<T: HttpClient + Clone + Send + Sync + 'static>(
 
 /// Handle a request using the Open Responses adapter
 ///
+/// Carry the upstream response's extensions (ServedBy, ResolvedTrust) onto a
+/// freshly built conversion response. Every adapter path that constructs a new
+/// `Response` from upstream `parts` must route through this — a site that
+/// forgets silently breaks provider attribution for integrators (which is
+/// exactly how the requires_action path was missed initially).
+fn carry_upstream_extensions(mut response: Response, extensions: Extensions) -> Response {
+    response.extensions_mut().extend(extensions);
+    response
+}
+
 /// This function implements the full Open Responses adapter flow including tool loop orchestration:
 /// 1. Convert Responses request to Chat Completions request
 /// 2. Forward to upstream
@@ -878,17 +888,20 @@ async fn handle_adapter_request<T: HttpClient + Clone + Send + Sync + 'static>(
                     }
                 };
 
-                return Response::builder()
-                    .status(parts.status)
-                    .header("content-type", "application/json")
-                    .body(Body::from(response_bytes))
-                    .unwrap_or_else(|_| {
-                        error_response(
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            "server_error",
-                            "Failed to build response",
-                        )
-                    });
+                return carry_upstream_extensions(
+                    Response::builder()
+                        .status(parts.status)
+                        .header("content-type", "application/json")
+                        .body(Body::from(response_bytes))
+                        .unwrap_or_else(|_| {
+                            error_response(
+                                StatusCode::INTERNAL_SERVER_ERROR,
+                                "server_error",
+                                "Failed to build response",
+                            )
+                        }),
+                    parts.extensions,
+                );
             }
 
             // All tools handled - add results to messages and continue loop
@@ -950,22 +963,20 @@ async fn handle_adapter_request<T: HttpClient + Clone + Send + Sync + 'static>(
             }
         };
 
-        let mut converted = Response::builder()
-            .status(parts.status)
-            .header("content-type", "application/json")
-            .body(Body::from(response_bytes))
-            .unwrap_or_else(|_| {
-                error_response(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "server_error",
-                    "Failed to build response",
-                )
-            });
-        // The conversion built a fresh response; carry over the upstream
-        // response's extensions (ServedBy, ResolvedTrust) so integrators can
-        // still attribute which provider served the final iteration.
-        converted.extensions_mut().extend(parts.extensions);
-        return converted;
+        return carry_upstream_extensions(
+            Response::builder()
+                .status(parts.status)
+                .header("content-type", "application/json")
+                .body(Body::from(response_bytes))
+                .unwrap_or_else(|_| {
+                    error_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "server_error",
+                        "Failed to build response",
+                    )
+                }),
+            parts.extensions,
+        );
     }
 }
 
@@ -1212,25 +1223,26 @@ async fn handle_streaming_adapter_request<T: HttpClient + Clone + Send + Sync + 
         }
     };
 
-    let mut converted = Response::builder()
-        .status(parts.status)
-        .header("content-type", "text/event-stream")
-        .header("cache-control", "no-cache")
-        .header("connection", "keep-alive")
-        .body(Body::from_stream(transformed_stream))
-        .unwrap_or_else(|_| {
-            error_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "server_error",
-                "Failed to build streaming response",
-            )
-        });
-    // The conversion built a fresh response; carry over the first upstream
-    // response's extensions (ServedBy, ResolvedTrust) so integrators can still
-    // attribute the serving provider. Tool-loop follow-ups discard their parts,
-    // so the initial provider stands in for the whole stream.
-    converted.extensions_mut().extend(parts.extensions);
-    converted
+    // Attribution note: for streaming tool loops the response (and its
+    // extensions) is returned before follow-up iterations run, so ServedBy
+    // necessarily names the provider of the initial iteration — the final
+    // iteration's provider is unknowable at header time.
+    carry_upstream_extensions(
+        Response::builder()
+            .status(parts.status)
+            .header("content-type", "text/event-stream")
+            .header("cache-control", "no-cache")
+            .header("connection", "keep-alive")
+            .body(Body::from_stream(transformed_stream))
+            .unwrap_or_else(|_| {
+                error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "server_error",
+                    "Failed to build streaming response",
+                )
+            }),
+        parts.extensions,
+    )
 }
 
 /// Forward a validated request to the upstream provider (returns raw response for adapter)


### PR DESCRIPTION
Follow-ups to the ServedBy extension (merged earlier) from a deeper review pass:

1. **Missed conversion exit**: the `requires_action` return in `handle_adapter_request` also builds a fresh response and was still dropping upstream extensions — `/v1/responses` requests with client-side tools lost `ServedBy`/`ResolvedTrust` attribution.
2. **Structural carry-over**: extension preservation is now a shared helper (`carry_upstream_extensions`) used by all three adapter conversion exits, so future conversion sites can't silently forget it (which is exactly how item 1 happened).
3. **Doc contract**: `ServedBy` docs now state the real semantics — present whenever an upstream produced the response (including passed-through non-2xx statuses; presence ≠ success), absent when no upstream answered; streaming tool loops attribute the initial iteration's provider since the response is returned before follow-up iterations run.

No behavior change for the already-covered paths. 477 lib tests green, clippy clean.

Worth landing before the v0.35.1 release PR merges so the release ships complete attribution.