### PR TITLE
feat: fusillade 22

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ metrics = "0.24"
 governor = "0.10.1"
 rand = "0.9"
 uuid = { version = "1", features = ["v4"] }
-fusillade = { version = "21.0.1", optional = true }
+fusillade = { version = "22.0.1", optional = true }
 
 [dev-dependencies]
 axum-test = "18.0.0"


### PR DESCRIPTION
## What

Bump the optional `multi-step` `fusillade` dependency from `21.0.1` to `22.0.1`.

## Why

fusillade 22 is a major release (real-duration recording for synthesized realtime rows). onwards' `multi-step` feature re-exposes fusillade types (`HttpClient`, `RequestData`, `RequestId`, `StreamEvent`, `StreamEventCallback`, `TemplateId`) through its public API, so consumers must share fusillade's major with onwards.

control-layer's `fix/realtime-duration` (#1287) needs dwctl on fusillade 22, which is blocked until onwards depends on fusillade 22 too. This bump unblocks it.

## Verification

onwards needs **no code changes** — it compiles cleanly against fusillade 22.0.1 (`cargo build --all-features`). Clippy shows only pre-existing warnings unrelated to this bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)