### PR TITLE
fix: update fusillade to 23.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,12 +978,13 @@ dependencies = [
 
 [[package]]
 name = "fusillade"
-version = "22.0.1"
+version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "207a954a5c551dd324b6b6fda2a2c6df84e691e49bf43b41c05429adafafd2e5"
+checksum = "7b650ac6823f234ab771fae06742830a7ff4d2f02e473a83474a750c89436595"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bytes",
  "chrono",
  "dashmap",
  "eventsource-stream",
@@ -991,6 +992,7 @@ dependencies = [
  "fusillade-core",
  "futures",
  "hostname",
+ "http-body",
  "humantime",
  "metrics",
  "openai-reassembler",
@@ -1012,9 +1014,9 @@ dependencies = [
 
 [[package]]
 name = "fusillade-arsenal"
-version = "2.0.1"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30f5635e1ce53339246b3eba6f5e2c1a289b295bd35134e1c9bf72315a17ab9c"
+checksum = "eb2a8f1fe5984d118df81a1cde3521f5ae506531957a2d0af53bf67fbeae2bde"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1040,9 +1042,9 @@ dependencies = [
 
 [[package]]
 name = "fusillade-core"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436000560d13e67d8008ca61e5f920bb7f41775dcdfc56a4340ce3849a04bad9"
+checksum = "0636f2967b04f6c761189d3aa5709c8306b280758dbd2751630cf04e7f0a6096"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ metrics = "0.24"
 governor = "0.10.1"
 rand = "0.9"
 uuid = { version = "1", features = ["v4"] }
-fusillade = { version = "22.0.1", optional = true }
+fusillade = { version = "23.0.1", optional = true }
 
 [dev-dependencies]
 axum-test = "18.0.0"


### PR DESCRIPTION
## Summary

- update the optional multi-step integration to Fusillade 23.0.1
- align its storage and core crates with the new major

## Verification

- `cargo check --all-features`
- `cargo test --all-features` (479 unit tests and 12 doctests passed)