### PR TITLE
feat: dispatch edge-translated Responses requests to the chat handler

### DIFF
--- a/src/strict/handlers.rs
+++ b/src/strict/handlers.rs
@@ -161,6 +161,20 @@ pub async fn responses_handler<T: HttpClient + Clone + Send + Sync + 'static>(
     headers: HeaderMap,
     req: Request<Body>,
 ) -> Response {
+    // An upstream edge (dwctl) may have already translated this Responses request
+    // into Chat Completions, normalising the path to `/chat/completions` as it did
+    // so. Axum cannot re-trigger route matching from a URI rewrite through a nest,
+    // so such a request still matches `/responses` and arrives here - with a body
+    // this handler's Responses schema would reject. Hand it to the chat handler.
+    // A native Responses request keeps its `/responses` path and falls through to
+    // the normal adapter/passthrough logic below.
+    if req.uri().path().ends_with("/chat/completions") {
+        return match Json::<ChatCompletionRequest>::from_request(req, &state).await {
+            Ok(chat_request) => chat_completions_handler(State(state), headers, chat_request).await,
+            Err(rejection) => rejection.into_response(),
+        };
+    }
+
     // Split the request so we can grab extensions (inserted by middleware)
     // before Axum's Json extractor consumes the body.
     let (mut parts, body) = req.into_parts();

--- a/src/strict/mod.rs
+++ b/src/strict/mod.rs
@@ -351,6 +351,40 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
     }
 
+    /// The dwctl edge translates a Responses request into Chat Completions and
+    /// normalises the path to `/chat/completions`, but that rewrite cannot
+    /// re-trigger route matching through a nest, so the request still arrives on
+    /// the `/responses` route carrying a Chat Completions body. `responses_handler`
+    /// must recognise the normalised path and hand it to the chat handler rather
+    /// than rejecting it against the Responses schema.
+    ///
+    /// Driven through the handler directly because routing in a test follows the
+    /// URI, so a router-level test cannot reproduce that path/route mismatch.
+    #[tokio::test]
+    async fn test_responses_handler_dispatches_edge_translated_body_to_chat() {
+        let state = create_test_app_state();
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("content-type", "application/json")
+            .body(Body::from(padded_chat_completions_body(16)))
+            .unwrap();
+
+        let response = handlers::responses_handler(
+            axum::extract::State(state),
+            axum::http::HeaderMap::new(),
+            request,
+        )
+        .await;
+
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "an edge-translated chat body on /responses must be served by the chat handler"
+        );
+    }
+
     #[tokio::test]
     async fn test_strict_router_accepts_base64_image_over_axum_2mb_default() {
         // The prod failure mode for COR-440: a vision request whose base64


### PR DESCRIPTION
# feat: dispatch edge-translated Responses requests to the chat handler

Minimal change so dwctl's edge can own Responses translation (control-layer COR-519)
without onwards rejecting the result. Nothing is removed: the Open Responses
adapter, schemas, passthrough mode and the tool loop all stay exactly as they are.

## The problem

dwctl's edge translates a `/responses` request into Chat Completions and normalises
the path to `/chat/completions` as it does so. Axum cannot re-trigger route matching
from a URI rewrite through a nest, so the request still matches the `/responses`
route and lands in `responses_handler` - carrying a Chat Completions body that the
Responses schema rejects.

## The change

`responses_handler` now checks for that normalised path up front and hands those
requests to `chat_completions_handler`:

```rust
if req.uri().path().ends_with("/chat/completions") {
    return match Json::<ChatCompletionRequest>::from_request(req, &state).await {
        Ok(chat_request) => chat_completions_handler(State(state), headers, chat_request).await,
        Err(rejection) => rejection.into_response(),
    };
}
```

A native Responses request keeps its `/responses` path and falls straight through to
the existing adapter / passthrough logic, untouched. `/messages` already worked this
way via its own alias.

## Testing

- `cargo test --lib`: 467 passed, 0 failed. Changed files are rustfmt clean.
- New `test_responses_handler_dispatches_edge_translated_body_to_chat`, driven
  through the handler directly - a router-level test cannot reproduce the
  path/route mismatch, since routing in a test follows the URI.

## Cross-repo note

Pairs with control-layer PR #1317, which adds the edge translation that produces
these requests.
